### PR TITLE
docs: Add page for encrypted messages

### DIFF
--- a/docs/help-center/using-famedly/encrypted-messages.mdx
+++ b/docs/help-center/using-famedly/encrypted-messages.mdx
@@ -1,0 +1,35 @@
+---
+sidebar_label: Encrypted Messages
+title: Encrypted Messages
+hide_title: true
+displayed_sidebar: helpcenterSidebar
+sidebar_position: 7
+---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+import useBaseUrl from '@docusaurus/useBaseUrl';
+
+
+<div class="hero hero--primary">
+  <div class="container">
+    <h2 class="hero__title">Login</h2>
+    <p class="hero__subtitle">How to deal with encrypted messages in Famedly</p>
+  </div>
+</div>
+
+## Why are my messages encrypted and unreadable?
+
+This can happen if the message was sent before you have signed in to your account at
+this device.
+
+It is also possible that the sender has blocked your device or something
+went wrong with the internet connection.
+
+Are you able to read the message on another
+session? Then you can transfer the message from it! Go to Settings > Devices and make sure
+that your devices have verified each other. When you open the room the next time and both
+sessions are in the foreground, the keys will be transmitted automatically.
+
+Do you not want to lose the keys when logging out or switching devices? Make sure that you have enabled
+the chat backup and do not lose your passphrase.

--- a/i18n/de/docusaurus-plugin-content-docs/current/help-center/using-famedly/encrypted-messages.mdx
+++ b/i18n/de/docusaurus-plugin-content-docs/current/help-center/using-famedly/encrypted-messages.mdx
@@ -1,0 +1,31 @@
+---
+sidebar_label: Verschlüsselte Nachrichten
+title: Verschlüsselte Nachrichten
+hide_title: true
+displayed_sidebar: helpcenterSidebar
+sidebar_position: 7
+---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+import useBaseUrl from '@docusaurus/useBaseUrl';
+
+
+<div class="hero hero--primary">
+  <div class="container">
+    <h2 class="hero__title">Login</h2>
+    <p class="hero__subtitle">Wie umgehen mit verschlüsselten Nachrichten in Famedly</p>
+  </div>
+</div>
+
+## Warum sind meine Nachrichten verschlüsselt und nicht lesbar?
+
+Dies kann passieren, wenn die Nachricht gesendet wurde, bevor Sie sich auf diesem Gerät bei Ihrem Konto angemeldet haben.
+
+Es ist auch möglich, dass der Absender ihr Gerät blockiert hat oder etwas mit der Internetverbindung schief gelaufen ist.
+
+Können Sie die Nachricht in einer anderen Sitzung lesen? Dann können Sie die Nachricht davon übertragen! Gehen Sie zu
+den Einstellungen > Geräte und vergewissern Sie sich, dass sich die Geräte gegenseitig verifiziert haben.
+Wenn Sie den Raum das nächste Mal öffnest und beide Sitzungen im Vordergrund sind, werden die Schlüssel automatisch übertragen.
+Sie möchten die Schlüssel beim Abmelden oder Gerätewechsel nicht verlieren? Stellen Sie sicher, dass Sie das Chat-Backup
+in den Einstellungen aktiviert haben und ihre Passphrase nicht verlieren.


### PR DESCRIPTION
This is more or less just copy pasted from fluffychat as a placeholder until we have a real helpcenter page for this topic. I just need something to link

Closes https://github.com/famedly/app/issues/5296