### PR TITLE
chore: Updated Dart Web passages on the message guide to Flutter Web

### DIFF
--- a/docs/help-center/using-famedly/messages.mdx
+++ b/docs/help-center/using-famedly/messages.mdx
@@ -100,8 +100,8 @@ Deleting a message is permanent, so please proceed with care.
 <Tabs>
   <TabItem value="desktop" label="Desktop" default>
   <ol>
-    <li>Hover over the message you want to delete.</li>
-    <li>Click the <b>Bin icon</b>.</li>
+    <li>Click on the message you want to delete.</li>
+    <li>Click the <b>Delete</b>.</li>
     <li>Click <b>Yes</b> to confirm.</li>
   </ol>
     </TabItem>
@@ -123,8 +123,8 @@ The reply function allows you to reply to a specific message in group chat or pr
 <Tabs>
   <TabItem value="desktop" label="Desktop" default>
   <ol>
-    <li>Hover over the message you want to answer.</li>
-    <li>Click the <b>Reply icon</b>.</li>
+    <li>Click on the message you want to answer.</li>
+    <li>Click on <b>Answer</b>.</li>
     <li>Enter your reply in the textfield.</li>
     <li>Press <b>Enter</b> or click the <b>Arrow</b> to send reply.</li>
   </ol>

--- a/i18n/de/docusaurus-plugin-content-docs/current/help-center/using-famedly/messages.mdx
+++ b/i18n/de/docusaurus-plugin-content-docs/current/help-center/using-famedly/messages.mdx
@@ -67,10 +67,10 @@ Standardmäßig können alle Mitglieder ihre Nachrichten bearbeiten.
 <Tabs>
   <TabItem value="desktop" label="Desktop" default>
   <ol>
-    <li>Bewegen Sie den Cursor über die Nachricht, die Sie bearbeiten möchten.</li>
-    <li>Klicken Sie auf das ✎ <b>Bleistift-Symbol</b>.</li>
+    <li>Klicken Sie auf die Nachricht, die Sie bearbeiten möchten.</li>
+    <li>Klicken Sie auf das <b>✎ Bearbeiten</b>.</li>
     <li>Bearbeiten Sie Ihre Nachricht im Textfeld.</li>
-    <li>Klicken Sie auf das →<b>Senden Symbol</b>.</li>
+    <li>Drücken Sie <b>Enter</b> oder klicken Sie auf das <b>Senden Symbol</b>.</li>
   </ol>
   </TabItem>
   <TabItem value="mobil" label="Mobil">
@@ -98,8 +98,8 @@ Das Löschen einer Nachricht ist permanent, also überlegen Sie es sich vorher g
 <Tabs>
   <TabItem value="desktop" label="Desktop" default>
   <ol>
-    <li>Bewegen Sie den Mauszeiger über die Nachricht, die Sie bearbeiten möchten.</li>
-    <li>Klicken Sie auf das <b>Papierkorb-Symbol</b>.</li>
+    <li>Klicken Sie auf die Nachricht, die Sie bearbeiten möchten.</li>
+    <li>Klicken Sie auf das <b>Löschen</b>.</li>
     <li>Klicken Sie auf <b>Ja</b>, um zu bestätigen.</li>
   </ol>
     </TabItem>


### PR DESCRIPTION
There were 2 descriptions for web that were clearly not up-to-date since we deprecated Dart Web in favour of Flutter Web. I updated those.