### PR TITLE
chore: Bump to docusaurus 3.0.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,19 +9,18 @@
       "version": "0.1.0",
       "dependencies": {
         "@crowdin/cli": "^3.14.0",
-        "@docusaurus/core": "3.0.0",
-        "@docusaurus/preset-classic": "3.0.0",
+        "@docusaurus/core": "3.0.1",
+        "@docusaurus/preset-classic": "3.0.1",
         "@mdx-js/react": "^3.0.0",
         "autoprefixer": "^10.4.14",
         "clsx": "^2.0.0",
         "postcss": "^8.4.26",
-        "prism-react-renderer": "^2.3.0",
-        "prism-themes": "^1.9.0",
+        "prism-react-renderer": "^2.3.1",
         "react": "^18.2.0",
         "react-dom": "^18.2.0"
       },
       "devDependencies": {
-        "@docusaurus/module-type-aliases": "3.0.0"
+        "@docusaurus/module-type-aliases": "3.0.1"
       },
       "engines": {
         "node": ">=18.0"
@@ -2181,12 +2180,12 @@
       }
     },
     "node_modules/@docusaurus/core": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-3.0.0.tgz",
-      "integrity": "sha512-bHWtY55tJTkd6pZhHrWz1MpWuwN4edZe0/UWgFF7PW/oJeDZvLSXKqwny3L91X1/LGGoypBGkeZn8EOuKeL4yQ==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-3.0.1.tgz",
+      "integrity": "sha512-CXrLpOnW+dJdSv8M5FAJ3JBwXtL6mhUWxFA8aS0ozK6jBG/wgxERk5uvH28fCeFxOGbAT9v1e9dOMo1X2IEVhQ==",
       "dependencies": {
-        "@babel/core": "^7.22.9",
-        "@babel/generator": "^7.22.9",
+        "@babel/core": "^7.23.3",
+        "@babel/generator": "^7.23.3",
         "@babel/plugin-syntax-dynamic-import": "^7.8.3",
         "@babel/plugin-transform-runtime": "^7.22.9",
         "@babel/preset-env": "^7.22.9",
@@ -2195,13 +2194,13 @@
         "@babel/runtime": "^7.22.6",
         "@babel/runtime-corejs3": "^7.22.6",
         "@babel/traverse": "^7.22.8",
-        "@docusaurus/cssnano-preset": "3.0.0",
-        "@docusaurus/logger": "3.0.0",
-        "@docusaurus/mdx-loader": "3.0.0",
+        "@docusaurus/cssnano-preset": "3.0.1",
+        "@docusaurus/logger": "3.0.1",
+        "@docusaurus/mdx-loader": "3.0.1",
         "@docusaurus/react-loadable": "5.5.2",
-        "@docusaurus/utils": "3.0.0",
-        "@docusaurus/utils-common": "3.0.0",
-        "@docusaurus/utils-validation": "3.0.0",
+        "@docusaurus/utils": "3.0.1",
+        "@docusaurus/utils-common": "3.0.1",
+        "@docusaurus/utils-validation": "3.0.1",
         "@slorber/static-site-generator-webpack-plugin": "^4.0.7",
         "@svgr/webpack": "^6.5.1",
         "autoprefixer": "^10.4.14",
@@ -2249,7 +2248,6 @@
         "tslib": "^2.6.0",
         "update-notifier": "^6.0.2",
         "url-loader": "^4.1.1",
-        "wait-on": "^7.0.1",
         "webpack": "^5.88.1",
         "webpack-bundle-analyzer": "^4.9.0",
         "webpack-dev-server": "^4.15.1",
@@ -2268,9 +2266,9 @@
       }
     },
     "node_modules/@docusaurus/cssnano-preset": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/cssnano-preset/-/cssnano-preset-3.0.0.tgz",
-      "integrity": "sha512-FHiRfwmVvIVdIGsHcijUOaX7hMn0mugVYB7m4GkpYI6Mi56zwQV4lH5p7DxcW5CUYNWMVxz2loWSCiWEm5ikwA==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/cssnano-preset/-/cssnano-preset-3.0.1.tgz",
+      "integrity": "sha512-wjuXzkHMW+ig4BD6Ya1Yevx9UJadO4smNZCEljqBoQfIQrQskTswBs7lZ8InHP7mCt273a/y/rm36EZhqJhknQ==",
       "dependencies": {
         "cssnano-preset-advanced": "^5.3.10",
         "postcss": "^8.4.26",
@@ -2282,9 +2280,9 @@
       }
     },
     "node_modules/@docusaurus/logger": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/logger/-/logger-3.0.0.tgz",
-      "integrity": "sha512-6eX0eOfioMQCk+qgCnHvbLLuyIAA+r2lSID6d6JusiLtDKmYMfNp3F4yyE8bnb0Abmzt2w68XwptEFYyALSAXw==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/logger/-/logger-3.0.1.tgz",
+      "integrity": "sha512-I5L6Nk8OJzkVA91O2uftmo71LBSxe1vmOn9AMR6JRCzYeEBrqneWMH02AqMvjJ2NpMiviO+t0CyPjyYV7nxCWQ==",
       "dependencies": {
         "chalk": "^4.1.2",
         "tslib": "^2.6.0"
@@ -2294,15 +2292,15 @@
       }
     },
     "node_modules/@docusaurus/mdx-loader": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/mdx-loader/-/mdx-loader-3.0.0.tgz",
-      "integrity": "sha512-JkGge6WYDrwjNgMxwkb6kNQHnpISt5L1tMaBWFDBKeDToFr5Kj29IL35MIQm0RfrnoOfr/29RjSH4aRtvlAR0A==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/mdx-loader/-/mdx-loader-3.0.1.tgz",
+      "integrity": "sha512-ldnTmvnvlrONUq45oKESrpy+lXtbnTcTsFkOTIDswe5xx5iWJjt6eSa0f99ZaWlnm24mlojcIGoUWNCS53qVlQ==",
       "dependencies": {
         "@babel/parser": "^7.22.7",
         "@babel/traverse": "^7.22.8",
-        "@docusaurus/logger": "3.0.0",
-        "@docusaurus/utils": "3.0.0",
-        "@docusaurus/utils-validation": "3.0.0",
+        "@docusaurus/logger": "3.0.1",
+        "@docusaurus/utils": "3.0.1",
+        "@docusaurus/utils-validation": "3.0.1",
         "@mdx-js/mdx": "^3.0.0",
         "@slorber/remark-comment": "^1.0.0",
         "escape-html": "^1.0.3",
@@ -2334,12 +2332,12 @@
       }
     },
     "node_modules/@docusaurus/module-type-aliases": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/module-type-aliases/-/module-type-aliases-3.0.0.tgz",
-      "integrity": "sha512-CfC6CgN4u/ce+2+L1JdsHNyBd8yYjl4De2B2CBj2a9F7WuJ5RjV1ciuU7KDg8uyju+NRVllRgvJvxVUjCdkPiw==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/module-type-aliases/-/module-type-aliases-3.0.1.tgz",
+      "integrity": "sha512-DEHpeqUDsLynl3AhQQiO7AbC7/z/lBra34jTcdYuvp9eGm01pfH1wTVq8YqWZq6Jyx0BgcVl/VJqtE9StRd9Ag==",
       "dependencies": {
         "@docusaurus/react-loadable": "5.5.2",
-        "@docusaurus/types": "3.0.0",
+        "@docusaurus/types": "3.0.1",
         "@types/history": "^4.7.11",
         "@types/react": "*",
         "@types/react-router-config": "*",
@@ -2353,17 +2351,17 @@
       }
     },
     "node_modules/@docusaurus/plugin-content-blog": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-blog/-/plugin-content-blog-3.0.0.tgz",
-      "integrity": "sha512-iA8Wc3tIzVnROJxrbIsU/iSfixHW16YeW9RWsBw7hgEk4dyGsip9AsvEDXobnRq3lVv4mfdgoS545iGWf1Ip9w==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-blog/-/plugin-content-blog-3.0.1.tgz",
+      "integrity": "sha512-cLOvtvAyaMQFLI8vm4j26svg3ktxMPSXpuUJ7EERKoGbfpJSsgtowNHcRsaBVmfuCsRSk1HZ/yHBsUkTmHFEsg==",
       "dependencies": {
-        "@docusaurus/core": "3.0.0",
-        "@docusaurus/logger": "3.0.0",
-        "@docusaurus/mdx-loader": "3.0.0",
-        "@docusaurus/types": "3.0.0",
-        "@docusaurus/utils": "3.0.0",
-        "@docusaurus/utils-common": "3.0.0",
-        "@docusaurus/utils-validation": "3.0.0",
+        "@docusaurus/core": "3.0.1",
+        "@docusaurus/logger": "3.0.1",
+        "@docusaurus/mdx-loader": "3.0.1",
+        "@docusaurus/types": "3.0.1",
+        "@docusaurus/utils": "3.0.1",
+        "@docusaurus/utils-common": "3.0.1",
+        "@docusaurus/utils-validation": "3.0.1",
         "cheerio": "^1.0.0-rc.12",
         "feed": "^4.2.2",
         "fs-extra": "^11.1.1",
@@ -2384,17 +2382,17 @@
       }
     },
     "node_modules/@docusaurus/plugin-content-docs": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-docs/-/plugin-content-docs-3.0.0.tgz",
-      "integrity": "sha512-MFZsOSwmeJ6rvoZMLieXxPuJsA9M9vn7/mUZmfUzSUTeHAeq+fEqvLltFOxcj4DVVDTYlQhgWYd+PISIWgamKw==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-docs/-/plugin-content-docs-3.0.1.tgz",
+      "integrity": "sha512-dRfAOA5Ivo+sdzzJGXEu33yAtvGg8dlZkvt/NEJ7nwi1F2j4LEdsxtfX2GKeETB2fP6XoGNSQnFXqa2NYGrHFg==",
       "dependencies": {
-        "@docusaurus/core": "3.0.0",
-        "@docusaurus/logger": "3.0.0",
-        "@docusaurus/mdx-loader": "3.0.0",
-        "@docusaurus/module-type-aliases": "3.0.0",
-        "@docusaurus/types": "3.0.0",
-        "@docusaurus/utils": "3.0.0",
-        "@docusaurus/utils-validation": "3.0.0",
+        "@docusaurus/core": "3.0.1",
+        "@docusaurus/logger": "3.0.1",
+        "@docusaurus/mdx-loader": "3.0.1",
+        "@docusaurus/module-type-aliases": "3.0.1",
+        "@docusaurus/types": "3.0.1",
+        "@docusaurus/utils": "3.0.1",
+        "@docusaurus/utils-validation": "3.0.1",
         "@types/react-router-config": "^5.0.7",
         "combine-promises": "^1.1.0",
         "fs-extra": "^11.1.1",
@@ -2413,15 +2411,15 @@
       }
     },
     "node_modules/@docusaurus/plugin-content-pages": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-pages/-/plugin-content-pages-3.0.0.tgz",
-      "integrity": "sha512-EXYHXK2Ea1B5BUmM0DgSwaOYt8EMSzWtYUToNo62Q/EoWxYOQFdWglYnw3n7ZEGyw5Kog4LHaRwlazAdmDomvQ==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-pages/-/plugin-content-pages-3.0.1.tgz",
+      "integrity": "sha512-oP7PoYizKAXyEttcvVzfX3OoBIXEmXTMzCdfmC4oSwjG4SPcJsRge3mmI6O8jcZBgUPjIzXD21bVGWEE1iu8gg==",
       "dependencies": {
-        "@docusaurus/core": "3.0.0",
-        "@docusaurus/mdx-loader": "3.0.0",
-        "@docusaurus/types": "3.0.0",
-        "@docusaurus/utils": "3.0.0",
-        "@docusaurus/utils-validation": "3.0.0",
+        "@docusaurus/core": "3.0.1",
+        "@docusaurus/mdx-loader": "3.0.1",
+        "@docusaurus/types": "3.0.1",
+        "@docusaurus/utils": "3.0.1",
+        "@docusaurus/utils-validation": "3.0.1",
         "fs-extra": "^11.1.1",
         "tslib": "^2.6.0",
         "webpack": "^5.88.1"
@@ -2435,15 +2433,15 @@
       }
     },
     "node_modules/@docusaurus/plugin-debug": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-debug/-/plugin-debug-3.0.0.tgz",
-      "integrity": "sha512-gSV07HfQgnUboVEb3lucuVyv5pEoy33E7QXzzn++3kSc/NLEimkjXh3sSnTGOishkxCqlFV9BHfY/VMm5Lko5g==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-debug/-/plugin-debug-3.0.1.tgz",
+      "integrity": "sha512-09dxZMdATky4qdsZGzhzlUvvC+ilQ2hKbYF+wez+cM2mGo4qHbv8+qKXqxq0CQZyimwlAOWQLoSozIXU0g0i7g==",
       "dependencies": {
-        "@docusaurus/core": "3.0.0",
-        "@docusaurus/types": "3.0.0",
-        "@docusaurus/utils": "3.0.0",
-        "@microlink/react-json-view": "^1.22.2",
+        "@docusaurus/core": "3.0.1",
+        "@docusaurus/types": "3.0.1",
+        "@docusaurus/utils": "3.0.1",
         "fs-extra": "^11.1.1",
+        "react-json-view-lite": "^1.2.0",
         "tslib": "^2.6.0"
       },
       "engines": {
@@ -2455,13 +2453,13 @@
       }
     },
     "node_modules/@docusaurus/plugin-google-analytics": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-analytics/-/plugin-google-analytics-3.0.0.tgz",
-      "integrity": "sha512-0zcLK8w+ohmSm1fjUQCqeRsjmQc0gflvXnaVA/QVVCtm2yCiBtkrSGQXqt4MdpD7Xq8mwo3qVd5nhIcvrcebqw==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-analytics/-/plugin-google-analytics-3.0.1.tgz",
+      "integrity": "sha512-jwseSz1E+g9rXQwDdr0ZdYNjn8leZBnKPjjQhMBEiwDoenL3JYFcNW0+p0sWoVF/f2z5t7HkKA+cYObrUh18gg==",
       "dependencies": {
-        "@docusaurus/core": "3.0.0",
-        "@docusaurus/types": "3.0.0",
-        "@docusaurus/utils-validation": "3.0.0",
+        "@docusaurus/core": "3.0.1",
+        "@docusaurus/types": "3.0.1",
+        "@docusaurus/utils-validation": "3.0.1",
         "tslib": "^2.6.0"
       },
       "engines": {
@@ -2473,13 +2471,13 @@
       }
     },
     "node_modules/@docusaurus/plugin-google-gtag": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-gtag/-/plugin-google-gtag-3.0.0.tgz",
-      "integrity": "sha512-asEKavw8fczUqvXu/s9kG2m1epLnHJ19W6CCCRZEmpnkZUZKiM8rlkDiEmxApwIc2JDDbIMk+Y2TMkJI8mInbQ==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-gtag/-/plugin-google-gtag-3.0.1.tgz",
+      "integrity": "sha512-UFTDvXniAWrajsulKUJ1DB6qplui1BlKLQZjX4F7qS/qfJ+qkKqSkhJ/F4VuGQ2JYeZstYb+KaUzUzvaPK1aRQ==",
       "dependencies": {
-        "@docusaurus/core": "3.0.0",
-        "@docusaurus/types": "3.0.0",
-        "@docusaurus/utils-validation": "3.0.0",
+        "@docusaurus/core": "3.0.1",
+        "@docusaurus/types": "3.0.1",
+        "@docusaurus/utils-validation": "3.0.1",
         "@types/gtag.js": "^0.0.12",
         "tslib": "^2.6.0"
       },
@@ -2492,13 +2490,13 @@
       }
     },
     "node_modules/@docusaurus/plugin-google-tag-manager": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-tag-manager/-/plugin-google-tag-manager-3.0.0.tgz",
-      "integrity": "sha512-lytgu2eyn+7p4WklJkpMGRhwC29ezj4IjPPmVJ8vGzcSl6JkR1sADTHLG5xWOMuci420xZl9dGEiLTQ8FjCRyA==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-tag-manager/-/plugin-google-tag-manager-3.0.1.tgz",
+      "integrity": "sha512-IPFvuz83aFuheZcWpTlAdiiX1RqWIHM+OH8wS66JgwAKOiQMR3+nLywGjkLV4bp52x7nCnwhNk1rE85Cpy/CIw==",
       "dependencies": {
-        "@docusaurus/core": "3.0.0",
-        "@docusaurus/types": "3.0.0",
-        "@docusaurus/utils-validation": "3.0.0",
+        "@docusaurus/core": "3.0.1",
+        "@docusaurus/types": "3.0.1",
+        "@docusaurus/utils-validation": "3.0.1",
         "tslib": "^2.6.0"
       },
       "engines": {
@@ -2510,16 +2508,16 @@
       }
     },
     "node_modules/@docusaurus/plugin-sitemap": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-sitemap/-/plugin-sitemap-3.0.0.tgz",
-      "integrity": "sha512-cfcONdWku56Oi7Hdus2uvUw/RKRRlIGMViiHLjvQ21CEsEqnQ297MRoIgjU28kL7/CXD/+OiANSq3T1ezAiMhA==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-sitemap/-/plugin-sitemap-3.0.1.tgz",
+      "integrity": "sha512-xARiWnjtVvoEniZudlCq5T9ifnhCu/GAZ5nA7XgyLfPcNpHQa241HZdsTlLtVcecEVVdllevBKOp7qknBBaMGw==",
       "dependencies": {
-        "@docusaurus/core": "3.0.0",
-        "@docusaurus/logger": "3.0.0",
-        "@docusaurus/types": "3.0.0",
-        "@docusaurus/utils": "3.0.0",
-        "@docusaurus/utils-common": "3.0.0",
-        "@docusaurus/utils-validation": "3.0.0",
+        "@docusaurus/core": "3.0.1",
+        "@docusaurus/logger": "3.0.1",
+        "@docusaurus/types": "3.0.1",
+        "@docusaurus/utils": "3.0.1",
+        "@docusaurus/utils-common": "3.0.1",
+        "@docusaurus/utils-validation": "3.0.1",
         "fs-extra": "^11.1.1",
         "sitemap": "^7.1.1",
         "tslib": "^2.6.0"
@@ -2533,23 +2531,23 @@
       }
     },
     "node_modules/@docusaurus/preset-classic": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/preset-classic/-/preset-classic-3.0.0.tgz",
-      "integrity": "sha512-90aOKZGZdi0+GVQV+wt8xx4M4GiDrBRke8NO8nWwytMEXNrxrBxsQYFRD1YlISLJSCiHikKf3Z/MovMnQpnZyg==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/preset-classic/-/preset-classic-3.0.1.tgz",
+      "integrity": "sha512-il9m9xZKKjoXn6h0cRcdnt6wce0Pv1y5t4xk2Wx7zBGhKG1idu4IFHtikHlD0QPuZ9fizpXspXcTzjL5FXc1Gw==",
       "dependencies": {
-        "@docusaurus/core": "3.0.0",
-        "@docusaurus/plugin-content-blog": "3.0.0",
-        "@docusaurus/plugin-content-docs": "3.0.0",
-        "@docusaurus/plugin-content-pages": "3.0.0",
-        "@docusaurus/plugin-debug": "3.0.0",
-        "@docusaurus/plugin-google-analytics": "3.0.0",
-        "@docusaurus/plugin-google-gtag": "3.0.0",
-        "@docusaurus/plugin-google-tag-manager": "3.0.0",
-        "@docusaurus/plugin-sitemap": "3.0.0",
-        "@docusaurus/theme-classic": "3.0.0",
-        "@docusaurus/theme-common": "3.0.0",
-        "@docusaurus/theme-search-algolia": "3.0.0",
-        "@docusaurus/types": "3.0.0"
+        "@docusaurus/core": "3.0.1",
+        "@docusaurus/plugin-content-blog": "3.0.1",
+        "@docusaurus/plugin-content-docs": "3.0.1",
+        "@docusaurus/plugin-content-pages": "3.0.1",
+        "@docusaurus/plugin-debug": "3.0.1",
+        "@docusaurus/plugin-google-analytics": "3.0.1",
+        "@docusaurus/plugin-google-gtag": "3.0.1",
+        "@docusaurus/plugin-google-tag-manager": "3.0.1",
+        "@docusaurus/plugin-sitemap": "3.0.1",
+        "@docusaurus/theme-classic": "3.0.1",
+        "@docusaurus/theme-common": "3.0.1",
+        "@docusaurus/theme-search-algolia": "3.0.1",
+        "@docusaurus/types": "3.0.1"
       },
       "engines": {
         "node": ">=18.0"
@@ -2572,30 +2570,30 @@
       }
     },
     "node_modules/@docusaurus/theme-classic": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-classic/-/theme-classic-3.0.0.tgz",
-      "integrity": "sha512-wWOHSrKMn7L4jTtXBsb5iEJ3xvTddBye5PjYBnWiCkTAlhle2yMdc4/qRXW35Ot+OV/VXu6YFG8XVUJEl99z0A==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-classic/-/theme-classic-3.0.1.tgz",
+      "integrity": "sha512-XD1FRXaJiDlmYaiHHdm27PNhhPboUah9rqIH0lMpBt5kYtsGjJzhqa27KuZvHLzOP2OEpqd2+GZ5b6YPq7Q05Q==",
       "dependencies": {
-        "@docusaurus/core": "3.0.0",
-        "@docusaurus/mdx-loader": "3.0.0",
-        "@docusaurus/module-type-aliases": "3.0.0",
-        "@docusaurus/plugin-content-blog": "3.0.0",
-        "@docusaurus/plugin-content-docs": "3.0.0",
-        "@docusaurus/plugin-content-pages": "3.0.0",
-        "@docusaurus/theme-common": "3.0.0",
-        "@docusaurus/theme-translations": "3.0.0",
-        "@docusaurus/types": "3.0.0",
-        "@docusaurus/utils": "3.0.0",
-        "@docusaurus/utils-common": "3.0.0",
-        "@docusaurus/utils-validation": "3.0.0",
+        "@docusaurus/core": "3.0.1",
+        "@docusaurus/mdx-loader": "3.0.1",
+        "@docusaurus/module-type-aliases": "3.0.1",
+        "@docusaurus/plugin-content-blog": "3.0.1",
+        "@docusaurus/plugin-content-docs": "3.0.1",
+        "@docusaurus/plugin-content-pages": "3.0.1",
+        "@docusaurus/theme-common": "3.0.1",
+        "@docusaurus/theme-translations": "3.0.1",
+        "@docusaurus/types": "3.0.1",
+        "@docusaurus/utils": "3.0.1",
+        "@docusaurus/utils-common": "3.0.1",
+        "@docusaurus/utils-validation": "3.0.1",
         "@mdx-js/react": "^3.0.0",
-        "clsx": "^1.2.1",
+        "clsx": "^2.0.0",
         "copy-text-to-clipboard": "^3.2.0",
         "infima": "0.2.0-alpha.43",
         "lodash": "^4.17.21",
         "nprogress": "^0.2.0",
         "postcss": "^8.4.26",
-        "prism-react-renderer": "^2.1.0",
+        "prism-react-renderer": "^2.3.0",
         "prismjs": "^1.29.0",
         "react-router-dom": "^5.3.4",
         "rtlcss": "^4.1.0",
@@ -2610,32 +2608,24 @@
         "react-dom": "^18.0.0"
       }
     },
-    "node_modules/@docusaurus/theme-classic/node_modules/clsx": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.2.1.tgz",
-      "integrity": "sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/@docusaurus/theme-common": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-common/-/theme-common-3.0.0.tgz",
-      "integrity": "sha512-PahRpCLRK5owCMEqcNtUeTMOkTUCzrJlKA+HLu7f+8osYOni617YurXvHASCsSTxurjXaLz/RqZMnASnqATxIA==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-common/-/theme-common-3.0.1.tgz",
+      "integrity": "sha512-cr9TOWXuIOL0PUfuXv6L5lPlTgaphKP+22NdVBOYah5jSq5XAAulJTjfe+IfLsEG4L7lJttLbhW7LXDFSAI7Ag==",
       "dependencies": {
-        "@docusaurus/mdx-loader": "3.0.0",
-        "@docusaurus/module-type-aliases": "3.0.0",
-        "@docusaurus/plugin-content-blog": "3.0.0",
-        "@docusaurus/plugin-content-docs": "3.0.0",
-        "@docusaurus/plugin-content-pages": "3.0.0",
-        "@docusaurus/utils": "3.0.0",
-        "@docusaurus/utils-common": "3.0.0",
+        "@docusaurus/mdx-loader": "3.0.1",
+        "@docusaurus/module-type-aliases": "3.0.1",
+        "@docusaurus/plugin-content-blog": "3.0.1",
+        "@docusaurus/plugin-content-docs": "3.0.1",
+        "@docusaurus/plugin-content-pages": "3.0.1",
+        "@docusaurus/utils": "3.0.1",
+        "@docusaurus/utils-common": "3.0.1",
         "@types/history": "^4.7.11",
         "@types/react": "*",
         "@types/react-router-config": "*",
-        "clsx": "^1.2.1",
+        "clsx": "^2.0.0",
         "parse-numeric-range": "^1.3.0",
-        "prism-react-renderer": "^2.1.0",
+        "prism-react-renderer": "^2.3.0",
         "tslib": "^2.6.0",
         "utility-types": "^3.10.0"
       },
@@ -2647,30 +2637,22 @@
         "react-dom": "^18.0.0"
       }
     },
-    "node_modules/@docusaurus/theme-common/node_modules/clsx": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.2.1.tgz",
-      "integrity": "sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/@docusaurus/theme-search-algolia": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-search-algolia/-/theme-search-algolia-3.0.0.tgz",
-      "integrity": "sha512-PyMUNIS9yu0dx7XffB13ti4TG47pJq3G2KE/INvOFb6M0kWh+wwCnucPg4WAOysHOPh+SD9fjlXILoLQstgEIA==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-search-algolia/-/theme-search-algolia-3.0.1.tgz",
+      "integrity": "sha512-DDiPc0/xmKSEdwFkXNf1/vH1SzJPzuJBar8kMcBbDAZk/SAmo/4lf6GU2drou4Ae60lN2waix+jYWTWcJRahSA==",
       "dependencies": {
         "@docsearch/react": "^3.5.2",
-        "@docusaurus/core": "3.0.0",
-        "@docusaurus/logger": "3.0.0",
-        "@docusaurus/plugin-content-docs": "3.0.0",
-        "@docusaurus/theme-common": "3.0.0",
-        "@docusaurus/theme-translations": "3.0.0",
-        "@docusaurus/utils": "3.0.0",
-        "@docusaurus/utils-validation": "3.0.0",
+        "@docusaurus/core": "3.0.1",
+        "@docusaurus/logger": "3.0.1",
+        "@docusaurus/plugin-content-docs": "3.0.1",
+        "@docusaurus/theme-common": "3.0.1",
+        "@docusaurus/theme-translations": "3.0.1",
+        "@docusaurus/utils": "3.0.1",
+        "@docusaurus/utils-validation": "3.0.1",
         "algoliasearch": "^4.18.0",
         "algoliasearch-helper": "^3.13.3",
-        "clsx": "^1.2.1",
+        "clsx": "^2.0.0",
         "eta": "^2.2.0",
         "fs-extra": "^11.1.1",
         "lodash": "^4.17.21",
@@ -2685,18 +2667,10 @@
         "react-dom": "^18.0.0"
       }
     },
-    "node_modules/@docusaurus/theme-search-algolia/node_modules/clsx": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.2.1.tgz",
-      "integrity": "sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/@docusaurus/theme-translations": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-translations/-/theme-translations-3.0.0.tgz",
-      "integrity": "sha512-p/H3+5LdnDtbMU+csYukA6601U1ld2v9knqxGEEV96qV27HsHfP63J9Ta2RBZUrNhQAgrwFzIc9GdDO8P1Baag==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-translations/-/theme-translations-3.0.1.tgz",
+      "integrity": "sha512-6UrbpzCTN6NIJnAtZ6Ne9492vmPVX+7Fsz4kmp+yor3KQwA1+MCzQP7ItDNkP38UmVLnvB/cYk/IvehCUqS3dg==",
       "dependencies": {
         "fs-extra": "^11.1.1",
         "tslib": "^2.6.0"
@@ -2706,9 +2680,9 @@
       }
     },
     "node_modules/@docusaurus/types": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-3.0.0.tgz",
-      "integrity": "sha512-Qb+l/hmCOVemReuzvvcFdk84bUmUFyD0Zi81y651ie3VwMrXqC7C0E7yZLKMOsLj/vkqsxHbtkAuYMI89YzNzg==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-3.0.1.tgz",
+      "integrity": "sha512-plyX2iU1tcUsF46uQ01pAd4JhexR7n0iiQ5MSnBFX6M6NSJgDYdru/i1/YNPKOnQHBoXGLHv0dNT6OAlDWNjrg==",
       "dependencies": {
         "@types/history": "^4.7.11",
         "@types/react": "*",
@@ -2725,11 +2699,11 @@
       }
     },
     "node_modules/@docusaurus/utils": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils/-/utils-3.0.0.tgz",
-      "integrity": "sha512-JwGjh5mtjG9XIAESyPxObL6CZ6LO/yU4OSTpq7Q0x+jN25zi/AMbvLjpSyZzWy+qm5uQiFiIhqFaOxvy+82Ekg==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/utils/-/utils-3.0.1.tgz",
+      "integrity": "sha512-TwZ33Am0q4IIbvjhUOs+zpjtD/mXNmLmEgeTGuRq01QzulLHuPhaBTTAC/DHu6kFx3wDgmgpAlaRuCHfTcXv8g==",
       "dependencies": {
-        "@docusaurus/logger": "3.0.0",
+        "@docusaurus/logger": "3.0.1",
         "@svgr/webpack": "^6.5.1",
         "escape-string-regexp": "^4.0.0",
         "file-loader": "^6.2.0",
@@ -2760,9 +2734,9 @@
       }
     },
     "node_modules/@docusaurus/utils-common": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils-common/-/utils-common-3.0.0.tgz",
-      "integrity": "sha512-7iJWAtt4AHf4PFEPlEPXko9LZD/dbYnhLe0q8e3GRK1EXZyRASah2lznpMwB3lLmVjq/FR6ZAKF+E0wlmL5j0g==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/utils-common/-/utils-common-3.0.1.tgz",
+      "integrity": "sha512-W0AxD6w6T8g6bNro8nBRWf7PeZ/nn7geEWM335qHU2DDDjHuV4UZjgUGP1AQsdcSikPrlIqTJJbKzer1lRSlIg==",
       "dependencies": {
         "tslib": "^2.6.0"
       },
@@ -2779,12 +2753,12 @@
       }
     },
     "node_modules/@docusaurus/utils-validation": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils-validation/-/utils-validation-3.0.0.tgz",
-      "integrity": "sha512-MlIGUspB/HBW5CYgHvRhmkZbeMiUWKbyVoCQYvbGN8S19SSzVgzyy97KRpcjCOYYeEdkhmRCUwFBJBlLg3IoNQ==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/utils-validation/-/utils-validation-3.0.1.tgz",
+      "integrity": "sha512-ujTnqSfyGQ7/4iZdB4RRuHKY/Nwm58IIb+41s5tCXOv/MBU2wGAjOHq3U+AEyJ8aKQcHbxvTKJaRchNHYUVUQg==",
       "dependencies": {
-        "@docusaurus/logger": "3.0.0",
-        "@docusaurus/utils": "3.0.0",
+        "@docusaurus/logger": "3.0.1",
+        "@docusaurus/utils": "3.0.1",
         "joi": "^17.9.2",
         "js-yaml": "^4.1.0",
         "tslib": "^2.6.0"
@@ -2938,33 +2912,6 @@
       "peerDependencies": {
         "@types/react": ">=16",
         "react": ">=16"
-      }
-    },
-    "node_modules/@microlink/react-json-view": {
-      "version": "1.23.0",
-      "resolved": "https://registry.npmjs.org/@microlink/react-json-view/-/react-json-view-1.23.0.tgz",
-      "integrity": "sha512-HYJ1nsfO4/qn8afnAMhuk7+5a1vcjEaS8Gm5Vpr1SqdHDY0yLBJGpA+9DvKyxyVKaUkXzKXt3Mif9RcmFSdtYg==",
-      "dependencies": {
-        "flux": "~4.0.1",
-        "react-base16-styling": "~0.6.0",
-        "react-lifecycles-compat": "~3.0.4",
-        "react-textarea-autosize": "~8.3.2"
-      },
-      "peerDependencies": {
-        "react": ">= 15",
-        "react-dom": ">= 15"
-      }
-    },
-    "node_modules/@microlink/react-json-view/node_modules/flux": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/flux/-/flux-4.0.4.tgz",
-      "integrity": "sha512-NCj3XlayA2UsapRpM7va6wU1+9rE5FIL7qoMcmxWHRzbp0yujihMBm9BBHZ1MDIk5h5o2Bl6eGiCe8rYELAmYw==",
-      "dependencies": {
-        "fbemitter": "^3.0.0",
-        "fbjs": "^3.0.1"
-      },
-      "peerDependencies": {
-        "react": "^15.0.2 || ^16.0.0 || ^17.0.0"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -4112,11 +4059,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/asap": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
-      "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA=="
-    },
     "node_modules/astring": {
       "version": "1.8.6",
       "resolved": "https://registry.npmjs.org/astring/-/astring-1.8.6.tgz",
@@ -4124,11 +4066,6 @@
       "bin": {
         "astring": "bin/astring"
       }
-    },
-    "node_modules/asynckit": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
     },
     "node_modules/at-least-node": {
       "version": "1.0.0",
@@ -4172,16 +4109,6 @@
       },
       "peerDependencies": {
         "postcss": "^8.1.0"
-      }
-    },
-    "node_modules/axios": {
-      "version": "1.6.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.2.tgz",
-      "integrity": "sha512-7i24Ri4pmDRfJTR7LDBhsOTtcm+9kjX5WiY1X3wIisx6G9So3pfMkEiU7emUBe46oceVImccTEM3k6C5dbVW8A==",
-      "dependencies": {
-        "follow-redirects": "^1.15.0",
-        "form-data": "^4.0.0",
-        "proxy-from-env": "^1.1.0"
       }
     },
     "node_modules/babel-loader": {
@@ -4265,11 +4192,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
-    },
-    "node_modules/base16": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/base16/-/base16-1.0.0.tgz",
-      "integrity": "sha512-pNdYkNPiJUnEhnfXV56+sQy8+AaPcG3POZAUnwr4EeqCUZFz4u2PePbo3e5Gj4ziYPCWGUZT9RHisvJKnwFuBQ=="
     },
     "node_modules/batch": {
       "version": "0.6.1",
@@ -4854,17 +4776,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/combined-stream": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
-      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "dependencies": {
-        "delayed-stream": "~1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
     "node_modules/comma-separated-tokens": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
@@ -5152,33 +5063,6 @@
       },
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/cross-fetch": {
-      "version": "3.1.8",
-      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.8.tgz",
-      "integrity": "sha512-cvA+JwZoU0Xq+h6WkMvAUqPEYy92Obet6UdKLfW60qn99ftItKjB5T+BkyWOFWe2pUyfQ+IJHmpOTznqk1M6Kg==",
-      "dependencies": {
-        "node-fetch": "^2.6.12"
-      }
-    },
-    "node_modules/cross-fetch/node_modules/node-fetch": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
-      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
-      "dependencies": {
-        "whatwg-url": "^5.0.0"
-      },
-      "engines": {
-        "node": "4.x || >=6.0.0"
-      },
-      "peerDependencies": {
-        "encoding": "^0.1.0"
-      },
-      "peerDependenciesMeta": {
-        "encoding": {
-          "optional": true
-        }
       }
     },
     "node_modules/cross-spawn": {
@@ -5620,14 +5504,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/delayed-stream": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-      "engines": {
-        "node": ">=0.4.0"
       }
     },
     "node_modules/depd": {
@@ -6331,33 +6207,6 @@
         "node": ">=0.8.0"
       }
     },
-    "node_modules/fbemitter": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/fbemitter/-/fbemitter-3.0.0.tgz",
-      "integrity": "sha512-KWKaceCwKQU0+HPoop6gn4eOHk50bBv/VxjJtGMfwmJt3D29JpN4H4eisCtIPA+a8GVBam+ldMMpMjJUvpDyHw==",
-      "dependencies": {
-        "fbjs": "^3.0.0"
-      }
-    },
-    "node_modules/fbjs": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-3.0.5.tgz",
-      "integrity": "sha512-ztsSx77JBtkuMrEypfhgc3cI0+0h+svqeie7xHbh1k/IKdcydnvadp/mUaGgjAOXQmQSxsqgaRhS3q9fy+1kxg==",
-      "dependencies": {
-        "cross-fetch": "^3.1.5",
-        "fbjs-css-vars": "^1.0.0",
-        "loose-envify": "^1.0.0",
-        "object-assign": "^4.1.0",
-        "promise": "^7.1.1",
-        "setimmediate": "^1.0.5",
-        "ua-parser-js": "^1.0.35"
-      }
-    },
-    "node_modules/fbjs-css-vars": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/fbjs-css-vars/-/fbjs-css-vars-1.0.2.tgz",
-      "integrity": "sha512-b2XGFAFdWZWg0phtAWLHCk836A1Xann+I+Dgd3Gk64MHKZO44FfoD1KxyvbSh0qZsIoXQGGlVztIY+oitJPpRQ=="
-    },
     "node_modules/fd-slicer": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
@@ -6665,19 +6514,6 @@
       "integrity": "sha512-4WK/bYZmj8xLr+HUCODHGF1ZFzsYffasLUgEiMBY4fgtltdO6B4WJtlSbPaDTLpYTcGVwM2qLnFTICEcNxs3kA==",
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/form-data": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
-      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.8",
-        "mime-types": "^2.1.12"
-      },
-      "engines": {
-        "node": ">= 6"
       }
     },
     "node_modules/form-data-encoder": {
@@ -8242,20 +8078,10 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
-    "node_modules/lodash.curry": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/lodash.curry/-/lodash.curry-4.1.1.tgz",
-      "integrity": "sha512-/u14pXGviLaweY5JI0IUzgzF2J6Ne8INyzAZjImcryjgkZ+ebruBxy2/JaOOkTqScddcYtakjhSaeemV8lR0tA=="
-    },
     "node_modules/lodash.debounce": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
       "integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow=="
-    },
-    "node_modules/lodash.flow": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.flow/-/lodash.flow-3.5.0.tgz",
-      "integrity": "sha512-ff3BX/tSioo+XojX4MOsOMhJw0nZoUEF011LX8g8d3gvjVbxd89cCio4BCXronjxcTUIJUoqKEUA+n4CqvvRPw=="
     },
     "node_modules/lodash.memoize": {
       "version": "4.1.2",
@@ -11802,9 +11628,9 @@
       }
     },
     "node_modules/prism-react-renderer": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/prism-react-renderer/-/prism-react-renderer-2.3.0.tgz",
-      "integrity": "sha512-UYRg2TkVIaI6tRVHC5OJ4/BxqPUxJkJvq/odLT/ykpt1zGYXooNperUxQcCvi87LyRnR4nCh81ceOA+e7nrydg==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/prism-react-renderer/-/prism-react-renderer-2.3.1.tgz",
+      "integrity": "sha512-Rdf+HzBLR7KYjzpJ1rSoxT9ioO85nZngQEoFIhL07XhtJHlCU3SOz0GJ6+qvMyQe0Se+BV3qpe6Yd/NmQF5Juw==",
       "dependencies": {
         "@types/prismjs": "^1.26.0",
         "clsx": "^2.0.0"
@@ -11812,11 +11638,6 @@
       "peerDependencies": {
         "react": ">=16.0.0"
       }
-    },
-    "node_modules/prism-themes": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/prism-themes/-/prism-themes-1.9.0.tgz",
-      "integrity": "sha512-tX2AYsehKDw1EORwBps+WhBFKc2kxfoFpQAjxBndbZKr4fRmMkv47XN0BghC/K1qwodB1otbe4oF23vUTFDokw=="
     },
     "node_modules/prismjs": {
       "version": "1.29.0",
@@ -11830,14 +11651,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
-    },
-    "node_modules/promise": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
-      "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
-      "dependencies": {
-        "asap": "~2.0.3"
-      }
     },
     "node_modules/prompts": {
       "version": "2.4.2",
@@ -11895,11 +11708,6 @@
         "node": ">= 0.10"
       }
     },
-    "node_modules/proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
-    },
     "node_modules/punycode": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
@@ -11918,11 +11726,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/pure-color": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/pure-color/-/pure-color-1.3.0.tgz",
-      "integrity": "sha512-QFADYnsVoBMw1srW7OVKEYjG+MbIa49s54w1MA1EDY6r2r/sTcKKYqRX1f4GYvnXP7eN/Pe9HFcX+hwzmrXRHA=="
     },
     "node_modules/qs": {
       "version": "6.11.0",
@@ -12045,17 +11848,6 @@
       },
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/react-base16-styling": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/react-base16-styling/-/react-base16-styling-0.6.0.tgz",
-      "integrity": "sha512-yvh/7CArceR/jNATXOKDlvTnPKPmGZz7zsenQ3jUwLzHkNUR0CvY3yGYJbWJ/nnxsL8Sgmt5cO3/SILVuPO6TQ==",
-      "dependencies": {
-        "base16": "^1.0.0",
-        "lodash.curry": "^4.0.1",
-        "lodash.flow": "^3.3.0",
-        "pure-color": "^1.2.0"
       }
     },
     "node_modules/react-dev-utils": {
@@ -12219,10 +12011,16 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
-    "node_modules/react-lifecycles-compat": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
-      "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
+    "node_modules/react-json-view-lite": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/react-json-view-lite/-/react-json-view-lite-1.2.1.tgz",
+      "integrity": "sha512-Itc0g86fytOmKZoIoJyGgvNqohWSbh3NXIKNgH6W6FT9PC1ck4xas1tT3Rr/b3UlFXyA9Jjaw9QSXdZy2JwGMQ==",
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "react": "^16.13.1 || ^17.0.0 || ^18.0.0"
+      }
     },
     "node_modules/react-loadable": {
       "name": "@docusaurus/react-loadable",
@@ -12298,22 +12096,6 @@
       },
       "peerDependencies": {
         "react": ">=15"
-      }
-    },
-    "node_modules/react-textarea-autosize": {
-      "version": "8.3.4",
-      "resolved": "https://registry.npmjs.org/react-textarea-autosize/-/react-textarea-autosize-8.3.4.tgz",
-      "integrity": "sha512-CdtmP8Dc19xL8/R6sWvtknD/eCXkQr30dtvC4VmGInhRsfF8X/ihXCq6+9l9qbxmKRiq407/7z5fxE7cVWQNgQ==",
-      "dependencies": {
-        "@babel/runtime": "^7.10.2",
-        "use-composed-ref": "^1.3.0",
-        "use-latest": "^1.2.1"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/readable-stream": {
@@ -12835,14 +12617,6 @@
         "queue-microtask": "^1.2.2"
       }
     },
-    "node_modules/rxjs": {
-      "version": "7.8.1",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
-      "integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
-      "dependencies": {
-        "tslib": "^2.1.0"
-      }
-    },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
@@ -13151,11 +12925,6 @@
       "engines": {
         "node": ">= 0.4"
       }
-    },
-    "node_modules/setimmediate": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
-      "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA=="
     },
     "node_modules/setprototypeof": {
       "version": "1.2.0",
@@ -13974,28 +13743,6 @@
         "node": ">=14.17"
       }
     },
-    "node_modules/ua-parser-js": {
-      "version": "1.0.37",
-      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-1.0.37.tgz",
-      "integrity": "sha512-bhTyI94tZofjo+Dn8SN6Zv8nBDvyXTymAdM3LDI/0IboIUwTu1rEhW7v2TfiVsoYWgkQ4kOVqnI8APUFbIQIFQ==",
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/ua-parser-js"
-        },
-        {
-          "type": "paypal",
-          "url": "https://paypal.me/faisalman"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/faisalman"
-        }
-      ],
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/undici-types": {
       "version": "5.26.5",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
@@ -14386,43 +14133,6 @@
         "url": "https://opencollective.com/webpack"
       }
     },
-    "node_modules/use-composed-ref": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/use-composed-ref/-/use-composed-ref-1.3.0.tgz",
-      "integrity": "sha512-GLMG0Jc/jiKov/3Ulid1wbv3r54K9HlMW29IWcDFPEqFkSO2nS0MuefWgMJpeHQ9YJeXDL3ZUF+P3jdXlZX/cQ==",
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
-      }
-    },
-    "node_modules/use-isomorphic-layout-effect": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/use-isomorphic-layout-effect/-/use-isomorphic-layout-effect-1.1.2.tgz",
-      "integrity": "sha512-49L8yCO3iGT/ZF9QttjwLF/ZD9Iwto5LnH5LmEdk/6cFmXddqi2ulF0edxTwjj+7mqvpVVGQWvbXZdn32wRSHA==",
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/use-latest": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/use-latest/-/use-latest-1.2.1.tgz",
-      "integrity": "sha512-xA+AVm/Wlg3e2P/JiItTziwS7FK92LWrDB0p+hgXloIMuVCeJJ8v6f0eeHyPZaJrM+usM1FkFfbNCrJGs8A/zw==",
-      "dependencies": {
-        "use-isomorphic-layout-effect": "^1.1.1"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -14508,24 +14218,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/wait-on": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/wait-on/-/wait-on-7.2.0.tgz",
-      "integrity": "sha512-wCQcHkRazgjG5XoAq9jbTMLpNIjoSlZslrJ2+N9MxDsGEv1HnFoVjOCexL0ESva7Y9cu350j+DWADdk54s4AFQ==",
-      "dependencies": {
-        "axios": "^1.6.1",
-        "joi": "^17.11.0",
-        "lodash": "^4.17.21",
-        "minimist": "^1.2.8",
-        "rxjs": "^7.8.1"
-      },
-      "bin": {
-        "wait-on": "bin/wait-on"
-      },
-      "engines": {
-        "node": ">=12.0.0"
       }
     },
     "node_modules/watchpack": {
@@ -16583,12 +16275,12 @@
       }
     },
     "@docusaurus/core": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-3.0.0.tgz",
-      "integrity": "sha512-bHWtY55tJTkd6pZhHrWz1MpWuwN4edZe0/UWgFF7PW/oJeDZvLSXKqwny3L91X1/LGGoypBGkeZn8EOuKeL4yQ==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-3.0.1.tgz",
+      "integrity": "sha512-CXrLpOnW+dJdSv8M5FAJ3JBwXtL6mhUWxFA8aS0ozK6jBG/wgxERk5uvH28fCeFxOGbAT9v1e9dOMo1X2IEVhQ==",
       "requires": {
-        "@babel/core": "^7.22.9",
-        "@babel/generator": "^7.22.9",
+        "@babel/core": "^7.23.3",
+        "@babel/generator": "^7.23.3",
         "@babel/plugin-syntax-dynamic-import": "^7.8.3",
         "@babel/plugin-transform-runtime": "^7.22.9",
         "@babel/preset-env": "^7.22.9",
@@ -16597,13 +16289,13 @@
         "@babel/runtime": "^7.22.6",
         "@babel/runtime-corejs3": "^7.22.6",
         "@babel/traverse": "^7.22.8",
-        "@docusaurus/cssnano-preset": "3.0.0",
-        "@docusaurus/logger": "3.0.0",
-        "@docusaurus/mdx-loader": "3.0.0",
+        "@docusaurus/cssnano-preset": "3.0.1",
+        "@docusaurus/logger": "3.0.1",
+        "@docusaurus/mdx-loader": "3.0.1",
         "@docusaurus/react-loadable": "5.5.2",
-        "@docusaurus/utils": "3.0.0",
-        "@docusaurus/utils-common": "3.0.0",
-        "@docusaurus/utils-validation": "3.0.0",
+        "@docusaurus/utils": "3.0.1",
+        "@docusaurus/utils-common": "3.0.1",
+        "@docusaurus/utils-validation": "3.0.1",
         "@slorber/static-site-generator-webpack-plugin": "^4.0.7",
         "@svgr/webpack": "^6.5.1",
         "autoprefixer": "^10.4.14",
@@ -16651,7 +16343,6 @@
         "tslib": "^2.6.0",
         "update-notifier": "^6.0.2",
         "url-loader": "^4.1.1",
-        "wait-on": "^7.0.1",
         "webpack": "^5.88.1",
         "webpack-bundle-analyzer": "^4.9.0",
         "webpack-dev-server": "^4.15.1",
@@ -16660,9 +16351,9 @@
       }
     },
     "@docusaurus/cssnano-preset": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/cssnano-preset/-/cssnano-preset-3.0.0.tgz",
-      "integrity": "sha512-FHiRfwmVvIVdIGsHcijUOaX7hMn0mugVYB7m4GkpYI6Mi56zwQV4lH5p7DxcW5CUYNWMVxz2loWSCiWEm5ikwA==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/cssnano-preset/-/cssnano-preset-3.0.1.tgz",
+      "integrity": "sha512-wjuXzkHMW+ig4BD6Ya1Yevx9UJadO4smNZCEljqBoQfIQrQskTswBs7lZ8InHP7mCt273a/y/rm36EZhqJhknQ==",
       "requires": {
         "cssnano-preset-advanced": "^5.3.10",
         "postcss": "^8.4.26",
@@ -16671,24 +16362,24 @@
       }
     },
     "@docusaurus/logger": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/logger/-/logger-3.0.0.tgz",
-      "integrity": "sha512-6eX0eOfioMQCk+qgCnHvbLLuyIAA+r2lSID6d6JusiLtDKmYMfNp3F4yyE8bnb0Abmzt2w68XwptEFYyALSAXw==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/logger/-/logger-3.0.1.tgz",
+      "integrity": "sha512-I5L6Nk8OJzkVA91O2uftmo71LBSxe1vmOn9AMR6JRCzYeEBrqneWMH02AqMvjJ2NpMiviO+t0CyPjyYV7nxCWQ==",
       "requires": {
         "chalk": "^4.1.2",
         "tslib": "^2.6.0"
       }
     },
     "@docusaurus/mdx-loader": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/mdx-loader/-/mdx-loader-3.0.0.tgz",
-      "integrity": "sha512-JkGge6WYDrwjNgMxwkb6kNQHnpISt5L1tMaBWFDBKeDToFr5Kj29IL35MIQm0RfrnoOfr/29RjSH4aRtvlAR0A==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/mdx-loader/-/mdx-loader-3.0.1.tgz",
+      "integrity": "sha512-ldnTmvnvlrONUq45oKESrpy+lXtbnTcTsFkOTIDswe5xx5iWJjt6eSa0f99ZaWlnm24mlojcIGoUWNCS53qVlQ==",
       "requires": {
         "@babel/parser": "^7.22.7",
         "@babel/traverse": "^7.22.8",
-        "@docusaurus/logger": "3.0.0",
-        "@docusaurus/utils": "3.0.0",
-        "@docusaurus/utils-validation": "3.0.0",
+        "@docusaurus/logger": "3.0.1",
+        "@docusaurus/utils": "3.0.1",
+        "@docusaurus/utils-validation": "3.0.1",
         "@mdx-js/mdx": "^3.0.0",
         "@slorber/remark-comment": "^1.0.0",
         "escape-html": "^1.0.3",
@@ -16713,12 +16404,12 @@
       }
     },
     "@docusaurus/module-type-aliases": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/module-type-aliases/-/module-type-aliases-3.0.0.tgz",
-      "integrity": "sha512-CfC6CgN4u/ce+2+L1JdsHNyBd8yYjl4De2B2CBj2a9F7WuJ5RjV1ciuU7KDg8uyju+NRVllRgvJvxVUjCdkPiw==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/module-type-aliases/-/module-type-aliases-3.0.1.tgz",
+      "integrity": "sha512-DEHpeqUDsLynl3AhQQiO7AbC7/z/lBra34jTcdYuvp9eGm01pfH1wTVq8YqWZq6Jyx0BgcVl/VJqtE9StRd9Ag==",
       "requires": {
         "@docusaurus/react-loadable": "5.5.2",
-        "@docusaurus/types": "3.0.0",
+        "@docusaurus/types": "3.0.1",
         "@types/history": "^4.7.11",
         "@types/react": "*",
         "@types/react-router-config": "*",
@@ -16728,17 +16419,17 @@
       }
     },
     "@docusaurus/plugin-content-blog": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-blog/-/plugin-content-blog-3.0.0.tgz",
-      "integrity": "sha512-iA8Wc3tIzVnROJxrbIsU/iSfixHW16YeW9RWsBw7hgEk4dyGsip9AsvEDXobnRq3lVv4mfdgoS545iGWf1Ip9w==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-blog/-/plugin-content-blog-3.0.1.tgz",
+      "integrity": "sha512-cLOvtvAyaMQFLI8vm4j26svg3ktxMPSXpuUJ7EERKoGbfpJSsgtowNHcRsaBVmfuCsRSk1HZ/yHBsUkTmHFEsg==",
       "requires": {
-        "@docusaurus/core": "3.0.0",
-        "@docusaurus/logger": "3.0.0",
-        "@docusaurus/mdx-loader": "3.0.0",
-        "@docusaurus/types": "3.0.0",
-        "@docusaurus/utils": "3.0.0",
-        "@docusaurus/utils-common": "3.0.0",
-        "@docusaurus/utils-validation": "3.0.0",
+        "@docusaurus/core": "3.0.1",
+        "@docusaurus/logger": "3.0.1",
+        "@docusaurus/mdx-loader": "3.0.1",
+        "@docusaurus/types": "3.0.1",
+        "@docusaurus/utils": "3.0.1",
+        "@docusaurus/utils-common": "3.0.1",
+        "@docusaurus/utils-validation": "3.0.1",
         "cheerio": "^1.0.0-rc.12",
         "feed": "^4.2.2",
         "fs-extra": "^11.1.1",
@@ -16752,17 +16443,17 @@
       }
     },
     "@docusaurus/plugin-content-docs": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-docs/-/plugin-content-docs-3.0.0.tgz",
-      "integrity": "sha512-MFZsOSwmeJ6rvoZMLieXxPuJsA9M9vn7/mUZmfUzSUTeHAeq+fEqvLltFOxcj4DVVDTYlQhgWYd+PISIWgamKw==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-docs/-/plugin-content-docs-3.0.1.tgz",
+      "integrity": "sha512-dRfAOA5Ivo+sdzzJGXEu33yAtvGg8dlZkvt/NEJ7nwi1F2j4LEdsxtfX2GKeETB2fP6XoGNSQnFXqa2NYGrHFg==",
       "requires": {
-        "@docusaurus/core": "3.0.0",
-        "@docusaurus/logger": "3.0.0",
-        "@docusaurus/mdx-loader": "3.0.0",
-        "@docusaurus/module-type-aliases": "3.0.0",
-        "@docusaurus/types": "3.0.0",
-        "@docusaurus/utils": "3.0.0",
-        "@docusaurus/utils-validation": "3.0.0",
+        "@docusaurus/core": "3.0.1",
+        "@docusaurus/logger": "3.0.1",
+        "@docusaurus/mdx-loader": "3.0.1",
+        "@docusaurus/module-type-aliases": "3.0.1",
+        "@docusaurus/types": "3.0.1",
+        "@docusaurus/utils": "3.0.1",
+        "@docusaurus/utils-validation": "3.0.1",
         "@types/react-router-config": "^5.0.7",
         "combine-promises": "^1.1.0",
         "fs-extra": "^11.1.1",
@@ -16774,101 +16465,101 @@
       }
     },
     "@docusaurus/plugin-content-pages": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-pages/-/plugin-content-pages-3.0.0.tgz",
-      "integrity": "sha512-EXYHXK2Ea1B5BUmM0DgSwaOYt8EMSzWtYUToNo62Q/EoWxYOQFdWglYnw3n7ZEGyw5Kog4LHaRwlazAdmDomvQ==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-pages/-/plugin-content-pages-3.0.1.tgz",
+      "integrity": "sha512-oP7PoYizKAXyEttcvVzfX3OoBIXEmXTMzCdfmC4oSwjG4SPcJsRge3mmI6O8jcZBgUPjIzXD21bVGWEE1iu8gg==",
       "requires": {
-        "@docusaurus/core": "3.0.0",
-        "@docusaurus/mdx-loader": "3.0.0",
-        "@docusaurus/types": "3.0.0",
-        "@docusaurus/utils": "3.0.0",
-        "@docusaurus/utils-validation": "3.0.0",
+        "@docusaurus/core": "3.0.1",
+        "@docusaurus/mdx-loader": "3.0.1",
+        "@docusaurus/types": "3.0.1",
+        "@docusaurus/utils": "3.0.1",
+        "@docusaurus/utils-validation": "3.0.1",
         "fs-extra": "^11.1.1",
         "tslib": "^2.6.0",
         "webpack": "^5.88.1"
       }
     },
     "@docusaurus/plugin-debug": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-debug/-/plugin-debug-3.0.0.tgz",
-      "integrity": "sha512-gSV07HfQgnUboVEb3lucuVyv5pEoy33E7QXzzn++3kSc/NLEimkjXh3sSnTGOishkxCqlFV9BHfY/VMm5Lko5g==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-debug/-/plugin-debug-3.0.1.tgz",
+      "integrity": "sha512-09dxZMdATky4qdsZGzhzlUvvC+ilQ2hKbYF+wez+cM2mGo4qHbv8+qKXqxq0CQZyimwlAOWQLoSozIXU0g0i7g==",
       "requires": {
-        "@docusaurus/core": "3.0.0",
-        "@docusaurus/types": "3.0.0",
-        "@docusaurus/utils": "3.0.0",
-        "@microlink/react-json-view": "^1.22.2",
+        "@docusaurus/core": "3.0.1",
+        "@docusaurus/types": "3.0.1",
+        "@docusaurus/utils": "3.0.1",
         "fs-extra": "^11.1.1",
+        "react-json-view-lite": "^1.2.0",
         "tslib": "^2.6.0"
       }
     },
     "@docusaurus/plugin-google-analytics": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-analytics/-/plugin-google-analytics-3.0.0.tgz",
-      "integrity": "sha512-0zcLK8w+ohmSm1fjUQCqeRsjmQc0gflvXnaVA/QVVCtm2yCiBtkrSGQXqt4MdpD7Xq8mwo3qVd5nhIcvrcebqw==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-analytics/-/plugin-google-analytics-3.0.1.tgz",
+      "integrity": "sha512-jwseSz1E+g9rXQwDdr0ZdYNjn8leZBnKPjjQhMBEiwDoenL3JYFcNW0+p0sWoVF/f2z5t7HkKA+cYObrUh18gg==",
       "requires": {
-        "@docusaurus/core": "3.0.0",
-        "@docusaurus/types": "3.0.0",
-        "@docusaurus/utils-validation": "3.0.0",
+        "@docusaurus/core": "3.0.1",
+        "@docusaurus/types": "3.0.1",
+        "@docusaurus/utils-validation": "3.0.1",
         "tslib": "^2.6.0"
       }
     },
     "@docusaurus/plugin-google-gtag": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-gtag/-/plugin-google-gtag-3.0.0.tgz",
-      "integrity": "sha512-asEKavw8fczUqvXu/s9kG2m1epLnHJ19W6CCCRZEmpnkZUZKiM8rlkDiEmxApwIc2JDDbIMk+Y2TMkJI8mInbQ==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-gtag/-/plugin-google-gtag-3.0.1.tgz",
+      "integrity": "sha512-UFTDvXniAWrajsulKUJ1DB6qplui1BlKLQZjX4F7qS/qfJ+qkKqSkhJ/F4VuGQ2JYeZstYb+KaUzUzvaPK1aRQ==",
       "requires": {
-        "@docusaurus/core": "3.0.0",
-        "@docusaurus/types": "3.0.0",
-        "@docusaurus/utils-validation": "3.0.0",
+        "@docusaurus/core": "3.0.1",
+        "@docusaurus/types": "3.0.1",
+        "@docusaurus/utils-validation": "3.0.1",
         "@types/gtag.js": "^0.0.12",
         "tslib": "^2.6.0"
       }
     },
     "@docusaurus/plugin-google-tag-manager": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-tag-manager/-/plugin-google-tag-manager-3.0.0.tgz",
-      "integrity": "sha512-lytgu2eyn+7p4WklJkpMGRhwC29ezj4IjPPmVJ8vGzcSl6JkR1sADTHLG5xWOMuci420xZl9dGEiLTQ8FjCRyA==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-tag-manager/-/plugin-google-tag-manager-3.0.1.tgz",
+      "integrity": "sha512-IPFvuz83aFuheZcWpTlAdiiX1RqWIHM+OH8wS66JgwAKOiQMR3+nLywGjkLV4bp52x7nCnwhNk1rE85Cpy/CIw==",
       "requires": {
-        "@docusaurus/core": "3.0.0",
-        "@docusaurus/types": "3.0.0",
-        "@docusaurus/utils-validation": "3.0.0",
+        "@docusaurus/core": "3.0.1",
+        "@docusaurus/types": "3.0.1",
+        "@docusaurus/utils-validation": "3.0.1",
         "tslib": "^2.6.0"
       }
     },
     "@docusaurus/plugin-sitemap": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-sitemap/-/plugin-sitemap-3.0.0.tgz",
-      "integrity": "sha512-cfcONdWku56Oi7Hdus2uvUw/RKRRlIGMViiHLjvQ21CEsEqnQ297MRoIgjU28kL7/CXD/+OiANSq3T1ezAiMhA==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-sitemap/-/plugin-sitemap-3.0.1.tgz",
+      "integrity": "sha512-xARiWnjtVvoEniZudlCq5T9ifnhCu/GAZ5nA7XgyLfPcNpHQa241HZdsTlLtVcecEVVdllevBKOp7qknBBaMGw==",
       "requires": {
-        "@docusaurus/core": "3.0.0",
-        "@docusaurus/logger": "3.0.0",
-        "@docusaurus/types": "3.0.0",
-        "@docusaurus/utils": "3.0.0",
-        "@docusaurus/utils-common": "3.0.0",
-        "@docusaurus/utils-validation": "3.0.0",
+        "@docusaurus/core": "3.0.1",
+        "@docusaurus/logger": "3.0.1",
+        "@docusaurus/types": "3.0.1",
+        "@docusaurus/utils": "3.0.1",
+        "@docusaurus/utils-common": "3.0.1",
+        "@docusaurus/utils-validation": "3.0.1",
         "fs-extra": "^11.1.1",
         "sitemap": "^7.1.1",
         "tslib": "^2.6.0"
       }
     },
     "@docusaurus/preset-classic": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/preset-classic/-/preset-classic-3.0.0.tgz",
-      "integrity": "sha512-90aOKZGZdi0+GVQV+wt8xx4M4GiDrBRke8NO8nWwytMEXNrxrBxsQYFRD1YlISLJSCiHikKf3Z/MovMnQpnZyg==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/preset-classic/-/preset-classic-3.0.1.tgz",
+      "integrity": "sha512-il9m9xZKKjoXn6h0cRcdnt6wce0Pv1y5t4xk2Wx7zBGhKG1idu4IFHtikHlD0QPuZ9fizpXspXcTzjL5FXc1Gw==",
       "requires": {
-        "@docusaurus/core": "3.0.0",
-        "@docusaurus/plugin-content-blog": "3.0.0",
-        "@docusaurus/plugin-content-docs": "3.0.0",
-        "@docusaurus/plugin-content-pages": "3.0.0",
-        "@docusaurus/plugin-debug": "3.0.0",
-        "@docusaurus/plugin-google-analytics": "3.0.0",
-        "@docusaurus/plugin-google-gtag": "3.0.0",
-        "@docusaurus/plugin-google-tag-manager": "3.0.0",
-        "@docusaurus/plugin-sitemap": "3.0.0",
-        "@docusaurus/theme-classic": "3.0.0",
-        "@docusaurus/theme-common": "3.0.0",
-        "@docusaurus/theme-search-algolia": "3.0.0",
-        "@docusaurus/types": "3.0.0"
+        "@docusaurus/core": "3.0.1",
+        "@docusaurus/plugin-content-blog": "3.0.1",
+        "@docusaurus/plugin-content-docs": "3.0.1",
+        "@docusaurus/plugin-content-pages": "3.0.1",
+        "@docusaurus/plugin-debug": "3.0.1",
+        "@docusaurus/plugin-google-analytics": "3.0.1",
+        "@docusaurus/plugin-google-gtag": "3.0.1",
+        "@docusaurus/plugin-google-tag-manager": "3.0.1",
+        "@docusaurus/plugin-sitemap": "3.0.1",
+        "@docusaurus/theme-classic": "3.0.1",
+        "@docusaurus/theme-common": "3.0.1",
+        "@docusaurus/theme-search-algolia": "3.0.1",
+        "@docusaurus/types": "3.0.1"
       }
     },
     "@docusaurus/react-loadable": {
@@ -16881,116 +16572,95 @@
       }
     },
     "@docusaurus/theme-classic": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-classic/-/theme-classic-3.0.0.tgz",
-      "integrity": "sha512-wWOHSrKMn7L4jTtXBsb5iEJ3xvTddBye5PjYBnWiCkTAlhle2yMdc4/qRXW35Ot+OV/VXu6YFG8XVUJEl99z0A==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-classic/-/theme-classic-3.0.1.tgz",
+      "integrity": "sha512-XD1FRXaJiDlmYaiHHdm27PNhhPboUah9rqIH0lMpBt5kYtsGjJzhqa27KuZvHLzOP2OEpqd2+GZ5b6YPq7Q05Q==",
       "requires": {
-        "@docusaurus/core": "3.0.0",
-        "@docusaurus/mdx-loader": "3.0.0",
-        "@docusaurus/module-type-aliases": "3.0.0",
-        "@docusaurus/plugin-content-blog": "3.0.0",
-        "@docusaurus/plugin-content-docs": "3.0.0",
-        "@docusaurus/plugin-content-pages": "3.0.0",
-        "@docusaurus/theme-common": "3.0.0",
-        "@docusaurus/theme-translations": "3.0.0",
-        "@docusaurus/types": "3.0.0",
-        "@docusaurus/utils": "3.0.0",
-        "@docusaurus/utils-common": "3.0.0",
-        "@docusaurus/utils-validation": "3.0.0",
+        "@docusaurus/core": "3.0.1",
+        "@docusaurus/mdx-loader": "3.0.1",
+        "@docusaurus/module-type-aliases": "3.0.1",
+        "@docusaurus/plugin-content-blog": "3.0.1",
+        "@docusaurus/plugin-content-docs": "3.0.1",
+        "@docusaurus/plugin-content-pages": "3.0.1",
+        "@docusaurus/theme-common": "3.0.1",
+        "@docusaurus/theme-translations": "3.0.1",
+        "@docusaurus/types": "3.0.1",
+        "@docusaurus/utils": "3.0.1",
+        "@docusaurus/utils-common": "3.0.1",
+        "@docusaurus/utils-validation": "3.0.1",
         "@mdx-js/react": "^3.0.0",
-        "clsx": "^1.2.1",
+        "clsx": "^2.0.0",
         "copy-text-to-clipboard": "^3.2.0",
         "infima": "0.2.0-alpha.43",
         "lodash": "^4.17.21",
         "nprogress": "^0.2.0",
         "postcss": "^8.4.26",
-        "prism-react-renderer": "^2.1.0",
+        "prism-react-renderer": "^2.3.0",
         "prismjs": "^1.29.0",
         "react-router-dom": "^5.3.4",
         "rtlcss": "^4.1.0",
         "tslib": "^2.6.0",
         "utility-types": "^3.10.0"
-      },
-      "dependencies": {
-        "clsx": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.2.1.tgz",
-          "integrity": "sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg=="
-        }
       }
     },
     "@docusaurus/theme-common": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-common/-/theme-common-3.0.0.tgz",
-      "integrity": "sha512-PahRpCLRK5owCMEqcNtUeTMOkTUCzrJlKA+HLu7f+8osYOni617YurXvHASCsSTxurjXaLz/RqZMnASnqATxIA==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-common/-/theme-common-3.0.1.tgz",
+      "integrity": "sha512-cr9TOWXuIOL0PUfuXv6L5lPlTgaphKP+22NdVBOYah5jSq5XAAulJTjfe+IfLsEG4L7lJttLbhW7LXDFSAI7Ag==",
       "requires": {
-        "@docusaurus/mdx-loader": "3.0.0",
-        "@docusaurus/module-type-aliases": "3.0.0",
-        "@docusaurus/plugin-content-blog": "3.0.0",
-        "@docusaurus/plugin-content-docs": "3.0.0",
-        "@docusaurus/plugin-content-pages": "3.0.0",
-        "@docusaurus/utils": "3.0.0",
-        "@docusaurus/utils-common": "3.0.0",
+        "@docusaurus/mdx-loader": "3.0.1",
+        "@docusaurus/module-type-aliases": "3.0.1",
+        "@docusaurus/plugin-content-blog": "3.0.1",
+        "@docusaurus/plugin-content-docs": "3.0.1",
+        "@docusaurus/plugin-content-pages": "3.0.1",
+        "@docusaurus/utils": "3.0.1",
+        "@docusaurus/utils-common": "3.0.1",
         "@types/history": "^4.7.11",
         "@types/react": "*",
         "@types/react-router-config": "*",
-        "clsx": "^1.2.1",
+        "clsx": "^2.0.0",
         "parse-numeric-range": "^1.3.0",
-        "prism-react-renderer": "^2.1.0",
+        "prism-react-renderer": "^2.3.0",
         "tslib": "^2.6.0",
         "utility-types": "^3.10.0"
-      },
-      "dependencies": {
-        "clsx": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.2.1.tgz",
-          "integrity": "sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg=="
-        }
       }
     },
     "@docusaurus/theme-search-algolia": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-search-algolia/-/theme-search-algolia-3.0.0.tgz",
-      "integrity": "sha512-PyMUNIS9yu0dx7XffB13ti4TG47pJq3G2KE/INvOFb6M0kWh+wwCnucPg4WAOysHOPh+SD9fjlXILoLQstgEIA==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-search-algolia/-/theme-search-algolia-3.0.1.tgz",
+      "integrity": "sha512-DDiPc0/xmKSEdwFkXNf1/vH1SzJPzuJBar8kMcBbDAZk/SAmo/4lf6GU2drou4Ae60lN2waix+jYWTWcJRahSA==",
       "requires": {
         "@docsearch/react": "^3.5.2",
-        "@docusaurus/core": "3.0.0",
-        "@docusaurus/logger": "3.0.0",
-        "@docusaurus/plugin-content-docs": "3.0.0",
-        "@docusaurus/theme-common": "3.0.0",
-        "@docusaurus/theme-translations": "3.0.0",
-        "@docusaurus/utils": "3.0.0",
-        "@docusaurus/utils-validation": "3.0.0",
+        "@docusaurus/core": "3.0.1",
+        "@docusaurus/logger": "3.0.1",
+        "@docusaurus/plugin-content-docs": "3.0.1",
+        "@docusaurus/theme-common": "3.0.1",
+        "@docusaurus/theme-translations": "3.0.1",
+        "@docusaurus/utils": "3.0.1",
+        "@docusaurus/utils-validation": "3.0.1",
         "algoliasearch": "^4.18.0",
         "algoliasearch-helper": "^3.13.3",
-        "clsx": "^1.2.1",
+        "clsx": "^2.0.0",
         "eta": "^2.2.0",
         "fs-extra": "^11.1.1",
         "lodash": "^4.17.21",
         "tslib": "^2.6.0",
         "utility-types": "^3.10.0"
-      },
-      "dependencies": {
-        "clsx": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.2.1.tgz",
-          "integrity": "sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg=="
-        }
       }
     },
     "@docusaurus/theme-translations": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-translations/-/theme-translations-3.0.0.tgz",
-      "integrity": "sha512-p/H3+5LdnDtbMU+csYukA6601U1ld2v9knqxGEEV96qV27HsHfP63J9Ta2RBZUrNhQAgrwFzIc9GdDO8P1Baag==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-translations/-/theme-translations-3.0.1.tgz",
+      "integrity": "sha512-6UrbpzCTN6NIJnAtZ6Ne9492vmPVX+7Fsz4kmp+yor3KQwA1+MCzQP7ItDNkP38UmVLnvB/cYk/IvehCUqS3dg==",
       "requires": {
         "fs-extra": "^11.1.1",
         "tslib": "^2.6.0"
       }
     },
     "@docusaurus/types": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-3.0.0.tgz",
-      "integrity": "sha512-Qb+l/hmCOVemReuzvvcFdk84bUmUFyD0Zi81y651ie3VwMrXqC7C0E7yZLKMOsLj/vkqsxHbtkAuYMI89YzNzg==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-3.0.1.tgz",
+      "integrity": "sha512-plyX2iU1tcUsF46uQ01pAd4JhexR7n0iiQ5MSnBFX6M6NSJgDYdru/i1/YNPKOnQHBoXGLHv0dNT6OAlDWNjrg==",
       "requires": {
         "@types/history": "^4.7.11",
         "@types/react": "*",
@@ -17003,11 +16673,11 @@
       }
     },
     "@docusaurus/utils": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils/-/utils-3.0.0.tgz",
-      "integrity": "sha512-JwGjh5mtjG9XIAESyPxObL6CZ6LO/yU4OSTpq7Q0x+jN25zi/AMbvLjpSyZzWy+qm5uQiFiIhqFaOxvy+82Ekg==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/utils/-/utils-3.0.1.tgz",
+      "integrity": "sha512-TwZ33Am0q4IIbvjhUOs+zpjtD/mXNmLmEgeTGuRq01QzulLHuPhaBTTAC/DHu6kFx3wDgmgpAlaRuCHfTcXv8g==",
       "requires": {
-        "@docusaurus/logger": "3.0.0",
+        "@docusaurus/logger": "3.0.1",
         "@svgr/webpack": "^6.5.1",
         "escape-string-regexp": "^4.0.0",
         "file-loader": "^6.2.0",
@@ -17027,20 +16697,20 @@
       }
     },
     "@docusaurus/utils-common": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils-common/-/utils-common-3.0.0.tgz",
-      "integrity": "sha512-7iJWAtt4AHf4PFEPlEPXko9LZD/dbYnhLe0q8e3GRK1EXZyRASah2lznpMwB3lLmVjq/FR6ZAKF+E0wlmL5j0g==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/utils-common/-/utils-common-3.0.1.tgz",
+      "integrity": "sha512-W0AxD6w6T8g6bNro8nBRWf7PeZ/nn7geEWM335qHU2DDDjHuV4UZjgUGP1AQsdcSikPrlIqTJJbKzer1lRSlIg==",
       "requires": {
         "tslib": "^2.6.0"
       }
     },
     "@docusaurus/utils-validation": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils-validation/-/utils-validation-3.0.0.tgz",
-      "integrity": "sha512-MlIGUspB/HBW5CYgHvRhmkZbeMiUWKbyVoCQYvbGN8S19SSzVgzyy97KRpcjCOYYeEdkhmRCUwFBJBlLg3IoNQ==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/utils-validation/-/utils-validation-3.0.1.tgz",
+      "integrity": "sha512-ujTnqSfyGQ7/4iZdB4RRuHKY/Nwm58IIb+41s5tCXOv/MBU2wGAjOHq3U+AEyJ8aKQcHbxvTKJaRchNHYUVUQg==",
       "requires": {
-        "@docusaurus/logger": "3.0.0",
-        "@docusaurus/utils": "3.0.0",
+        "@docusaurus/logger": "3.0.1",
+        "@docusaurus/utils": "3.0.1",
         "joi": "^17.9.2",
         "js-yaml": "^4.1.0",
         "tslib": "^2.6.0"
@@ -17164,28 +16834,6 @@
       "integrity": "sha512-nDctevR9KyYFyV+m+/+S4cpzCWHqj+iHDHq3QrsWezcC+B17uZdIWgCguESUkwFhM3n/56KxWVE3V6EokrmONQ==",
       "requires": {
         "@types/mdx": "^2.0.0"
-      }
-    },
-    "@microlink/react-json-view": {
-      "version": "1.23.0",
-      "resolved": "https://registry.npmjs.org/@microlink/react-json-view/-/react-json-view-1.23.0.tgz",
-      "integrity": "sha512-HYJ1nsfO4/qn8afnAMhuk7+5a1vcjEaS8Gm5Vpr1SqdHDY0yLBJGpA+9DvKyxyVKaUkXzKXt3Mif9RcmFSdtYg==",
-      "requires": {
-        "flux": "~4.0.1",
-        "react-base16-styling": "~0.6.0",
-        "react-lifecycles-compat": "~3.0.4",
-        "react-textarea-autosize": "~8.3.2"
-      },
-      "dependencies": {
-        "flux": {
-          "version": "4.0.4",
-          "resolved": "https://registry.npmjs.org/flux/-/flux-4.0.4.tgz",
-          "integrity": "sha512-NCj3XlayA2UsapRpM7va6wU1+9rE5FIL7qoMcmxWHRzbp0yujihMBm9BBHZ1MDIk5h5o2Bl6eGiCe8rYELAmYw==",
-          "requires": {
-            "fbemitter": "^3.0.0",
-            "fbjs": "^3.0.1"
-          }
-        }
       }
     },
     "@nodelib/fs.scandir": {
@@ -18113,20 +17761,10 @@
       "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
       "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw=="
     },
-    "asap": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
-      "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA=="
-    },
     "astring": {
       "version": "1.8.6",
       "resolved": "https://registry.npmjs.org/astring/-/astring-1.8.6.tgz",
       "integrity": "sha512-ISvCdHdlTDlH5IpxQJIex7BWBywFWgjJSVdwst+/iQCoEYnyOaQ95+X1JGshuBjGp6nxKUy1jMgE3zPqN7fQdg=="
-    },
-    "asynckit": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
     },
     "at-least-node": {
       "version": "1.0.0",
@@ -18144,16 +17782,6 @@
         "normalize-range": "^0.1.2",
         "picocolors": "^1.0.0",
         "postcss-value-parser": "^4.2.0"
-      }
-    },
-    "axios": {
-      "version": "1.6.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.2.tgz",
-      "integrity": "sha512-7i24Ri4pmDRfJTR7LDBhsOTtcm+9kjX5WiY1X3wIisx6G9So3pfMkEiU7emUBe46oceVImccTEM3k6C5dbVW8A==",
-      "requires": {
-        "follow-redirects": "^1.15.0",
-        "form-data": "^4.0.0",
-        "proxy-from-env": "^1.1.0"
       }
     },
     "babel-loader": {
@@ -18216,11 +17844,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
-    },
-    "base16": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/base16/-/base16-1.0.0.tgz",
-      "integrity": "sha512-pNdYkNPiJUnEhnfXV56+sQy8+AaPcG3POZAUnwr4EeqCUZFz4u2PePbo3e5Gj4ziYPCWGUZT9RHisvJKnwFuBQ=="
     },
     "batch": {
       "version": "0.6.1",
@@ -18626,14 +18249,6 @@
       "resolved": "https://registry.npmjs.org/combine-promises/-/combine-promises-1.2.0.tgz",
       "integrity": "sha512-VcQB1ziGD0NXrhKxiwyNbCDmRzs/OShMs2GqW2DlU2A/Sd0nQxE1oWDAE5O0ygSx5mgQOn9eIFh7yKPgFRVkPQ=="
     },
-    "combined-stream": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
-      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "requires": {
-        "delayed-stream": "~1.0.0"
-      }
-    },
     "comma-separated-tokens": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
@@ -18842,24 +18457,6 @@
         "parse-json": "^5.0.0",
         "path-type": "^4.0.0",
         "yaml": "^1.10.0"
-      }
-    },
-    "cross-fetch": {
-      "version": "3.1.8",
-      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.8.tgz",
-      "integrity": "sha512-cvA+JwZoU0Xq+h6WkMvAUqPEYy92Obet6UdKLfW60qn99ftItKjB5T+BkyWOFWe2pUyfQ+IJHmpOTznqk1M6Kg==",
-      "requires": {
-        "node-fetch": "^2.6.12"
-      },
-      "dependencies": {
-        "node-fetch": {
-          "version": "2.7.0",
-          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
-          "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
-          "requires": {
-            "whatwg-url": "^5.0.0"
-          }
-        }
       }
     },
     "cross-spawn": {
@@ -19142,11 +18739,6 @@
         "rimraf": "^3.0.2",
         "slash": "^3.0.0"
       }
-    },
-    "delayed-stream": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="
     },
     "depd": {
       "version": "2.0.0",
@@ -19674,33 +19266,6 @@
         "websocket-driver": ">=0.5.1"
       }
     },
-    "fbemitter": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/fbemitter/-/fbemitter-3.0.0.tgz",
-      "integrity": "sha512-KWKaceCwKQU0+HPoop6gn4eOHk50bBv/VxjJtGMfwmJt3D29JpN4H4eisCtIPA+a8GVBam+ldMMpMjJUvpDyHw==",
-      "requires": {
-        "fbjs": "^3.0.0"
-      }
-    },
-    "fbjs": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-3.0.5.tgz",
-      "integrity": "sha512-ztsSx77JBtkuMrEypfhgc3cI0+0h+svqeie7xHbh1k/IKdcydnvadp/mUaGgjAOXQmQSxsqgaRhS3q9fy+1kxg==",
-      "requires": {
-        "cross-fetch": "^3.1.5",
-        "fbjs-css-vars": "^1.0.0",
-        "loose-envify": "^1.0.0",
-        "object-assign": "^4.1.0",
-        "promise": "^7.1.1",
-        "setimmediate": "^1.0.5",
-        "ua-parser-js": "^1.0.35"
-      }
-    },
-    "fbjs-css-vars": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/fbjs-css-vars/-/fbjs-css-vars-1.0.2.tgz",
-      "integrity": "sha512-b2XGFAFdWZWg0phtAWLHCk836A1Xann+I+Dgd3Gk64MHKZO44FfoD1KxyvbSh0qZsIoXQGGlVztIY+oitJPpRQ=="
-    },
     "fd-slicer": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
@@ -19910,16 +19475,6 @@
           "resolved": "https://registry.npmjs.org/tapable/-/tapable-1.1.3.tgz",
           "integrity": "sha512-4WK/bYZmj8xLr+HUCODHGF1ZFzsYffasLUgEiMBY4fgtltdO6B4WJtlSbPaDTLpYTcGVwM2qLnFTICEcNxs3kA=="
         }
-      }
-    },
-    "form-data": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
-      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
-      "requires": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.8",
-        "mime-types": "^2.1.12"
       }
     },
     "form-data-encoder": {
@@ -21044,20 +20599,10 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
-    "lodash.curry": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/lodash.curry/-/lodash.curry-4.1.1.tgz",
-      "integrity": "sha512-/u14pXGviLaweY5JI0IUzgzF2J6Ne8INyzAZjImcryjgkZ+ebruBxy2/JaOOkTqScddcYtakjhSaeemV8lR0tA=="
-    },
     "lodash.debounce": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
       "integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow=="
-    },
-    "lodash.flow": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.flow/-/lodash.flow-3.5.0.tgz",
-      "integrity": "sha512-ff3BX/tSioo+XojX4MOsOMhJw0nZoUEF011LX8g8d3gvjVbxd89cCio4BCXronjxcTUIJUoqKEUA+n4CqvvRPw=="
     },
     "lodash.memoize": {
       "version": "4.1.2",
@@ -23182,18 +22727,13 @@
       "integrity": "sha512-28iF6xPQrP8Oa6uxE6a1biz+lWeTOAPKggvjB8HAs6nVMKZwf5bG++632Dx614hIWgUPkgivRfG+a8uAXGTIbA=="
     },
     "prism-react-renderer": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/prism-react-renderer/-/prism-react-renderer-2.3.0.tgz",
-      "integrity": "sha512-UYRg2TkVIaI6tRVHC5OJ4/BxqPUxJkJvq/odLT/ykpt1zGYXooNperUxQcCvi87LyRnR4nCh81ceOA+e7nrydg==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/prism-react-renderer/-/prism-react-renderer-2.3.1.tgz",
+      "integrity": "sha512-Rdf+HzBLR7KYjzpJ1rSoxT9ioO85nZngQEoFIhL07XhtJHlCU3SOz0GJ6+qvMyQe0Se+BV3qpe6Yd/NmQF5Juw==",
       "requires": {
         "@types/prismjs": "^1.26.0",
         "clsx": "^2.0.0"
       }
-    },
-    "prism-themes": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/prism-themes/-/prism-themes-1.9.0.tgz",
-      "integrity": "sha512-tX2AYsehKDw1EORwBps+WhBFKc2kxfoFpQAjxBndbZKr4fRmMkv47XN0BghC/K1qwodB1otbe4oF23vUTFDokw=="
     },
     "prismjs": {
       "version": "1.29.0",
@@ -23204,14 +22744,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
-    },
-    "promise": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
-      "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
-      "requires": {
-        "asap": "~2.0.3"
-      }
     },
     "prompts": {
       "version": "2.4.2",
@@ -23258,11 +22790,6 @@
         }
       }
     },
-    "proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
-    },
     "punycode": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
@@ -23275,11 +22802,6 @@
       "requires": {
         "escape-goat": "^4.0.0"
       }
-    },
-    "pure-color": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/pure-color/-/pure-color-1.3.0.tgz",
-      "integrity": "sha512-QFADYnsVoBMw1srW7OVKEYjG+MbIa49s54w1MA1EDY6r2r/sTcKKYqRX1f4GYvnXP7eN/Pe9HFcX+hwzmrXRHA=="
     },
     "qs": {
       "version": "6.11.0",
@@ -23362,17 +22884,6 @@
       "integrity": "sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==",
       "requires": {
         "loose-envify": "^1.1.0"
-      }
-    },
-    "react-base16-styling": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/react-base16-styling/-/react-base16-styling-0.6.0.tgz",
-      "integrity": "sha512-yvh/7CArceR/jNATXOKDlvTnPKPmGZz7zsenQ3jUwLzHkNUR0CvY3yGYJbWJ/nnxsL8Sgmt5cO3/SILVuPO6TQ==",
-      "requires": {
-        "base16": "^1.0.0",
-        "lodash.curry": "^4.0.1",
-        "lodash.flow": "^3.3.0",
-        "pure-color": "^1.2.0"
       }
     },
     "react-dev-utils": {
@@ -23492,10 +23003,11 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
-    "react-lifecycles-compat": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
-      "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
+    "react-json-view-lite": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/react-json-view-lite/-/react-json-view-lite-1.2.1.tgz",
+      "integrity": "sha512-Itc0g86fytOmKZoIoJyGgvNqohWSbh3NXIKNgH6W6FT9PC1ck4xas1tT3Rr/b3UlFXyA9Jjaw9QSXdZy2JwGMQ==",
+      "requires": {}
     },
     "react-loadable": {
       "version": "npm:@docusaurus/react-loadable@5.5.2",
@@ -23550,16 +23062,6 @@
         "react-router": "5.3.4",
         "tiny-invariant": "^1.0.2",
         "tiny-warning": "^1.0.0"
-      }
-    },
-    "react-textarea-autosize": {
-      "version": "8.3.4",
-      "resolved": "https://registry.npmjs.org/react-textarea-autosize/-/react-textarea-autosize-8.3.4.tgz",
-      "integrity": "sha512-CdtmP8Dc19xL8/R6sWvtknD/eCXkQr30dtvC4VmGInhRsfF8X/ihXCq6+9l9qbxmKRiq407/7z5fxE7cVWQNgQ==",
-      "requires": {
-        "@babel/runtime": "^7.10.2",
-        "use-composed-ref": "^1.3.0",
-        "use-latest": "^1.2.1"
       }
     },
     "readable-stream": {
@@ -23935,14 +23437,6 @@
         "queue-microtask": "^1.2.2"
       }
     },
-    "rxjs": {
-      "version": "7.8.1",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
-      "integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
-      "requires": {
-        "tslib": "^2.1.0"
-      }
-    },
     "safe-buffer": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
@@ -24195,11 +23689,6 @@
         "gopd": "^1.0.1",
         "has-property-descriptors": "^1.0.0"
       }
-    },
-    "setimmediate": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
-      "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA=="
     },
     "setprototypeof": {
       "version": "1.2.0",
@@ -24787,11 +24276,6 @@
       "integrity": "sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==",
       "peer": true
     },
-    "ua-parser-js": {
-      "version": "1.0.37",
-      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-1.0.37.tgz",
-      "integrity": "sha512-bhTyI94tZofjo+Dn8SN6Zv8nBDvyXTymAdM3LDI/0IboIUwTu1rEhW7v2TfiVsoYWgkQ4kOVqnI8APUFbIQIFQ=="
-    },
     "undici-types": {
       "version": "5.26.5",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
@@ -25047,26 +24531,6 @@
         }
       }
     },
-    "use-composed-ref": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/use-composed-ref/-/use-composed-ref-1.3.0.tgz",
-      "integrity": "sha512-GLMG0Jc/jiKov/3Ulid1wbv3r54K9HlMW29IWcDFPEqFkSO2nS0MuefWgMJpeHQ9YJeXDL3ZUF+P3jdXlZX/cQ==",
-      "requires": {}
-    },
-    "use-isomorphic-layout-effect": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/use-isomorphic-layout-effect/-/use-isomorphic-layout-effect-1.1.2.tgz",
-      "integrity": "sha512-49L8yCO3iGT/ZF9QttjwLF/ZD9Iwto5LnH5LmEdk/6cFmXddqi2ulF0edxTwjj+7mqvpVVGQWvbXZdn32wRSHA==",
-      "requires": {}
-    },
-    "use-latest": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/use-latest/-/use-latest-1.2.1.tgz",
-      "integrity": "sha512-xA+AVm/Wlg3e2P/JiItTziwS7FK92LWrDB0p+hgXloIMuVCeJJ8v6f0eeHyPZaJrM+usM1FkFfbNCrJGs8A/zw==",
-      "requires": {
-        "use-isomorphic-layout-effect": "^1.1.1"
-      }
-    },
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -25128,18 +24592,6 @@
       "requires": {
         "@types/unist": "^3.0.0",
         "unist-util-stringify-position": "^4.0.0"
-      }
-    },
-    "wait-on": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/wait-on/-/wait-on-7.2.0.tgz",
-      "integrity": "sha512-wCQcHkRazgjG5XoAq9jbTMLpNIjoSlZslrJ2+N9MxDsGEv1HnFoVjOCexL0ESva7Y9cu350j+DWADdk54s4AFQ==",
-      "requires": {
-        "axios": "^1.6.1",
-        "joi": "^17.11.0",
-        "lodash": "^4.17.21",
-        "minimist": "^1.2.8",
-        "rxjs": "^7.8.1"
       }
     },
     "watchpack": {

--- a/package.json
+++ b/package.json
@@ -18,19 +18,18 @@
   },
   "dependencies": {
     "@crowdin/cli": "^3.14.0",
-    "@docusaurus/core": "3.0.0",
-    "@docusaurus/preset-classic": "3.0.0",
+    "@docusaurus/core": "3.0.1",
+    "@docusaurus/preset-classic": "3.0.1",
     "@mdx-js/react": "^3.0.0",
     "autoprefixer": "^10.4.14",
     "clsx": "^2.0.0",
     "postcss": "^8.4.26",
-    "prism-react-renderer": "^2.3.0",
-    "prism-themes": "^1.9.0",
+    "prism-react-renderer": "^2.3.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },
   "devDependencies": {
-    "@docusaurus/module-type-aliases": "3.0.0"
+    "@docusaurus/module-type-aliases": "3.0.1"
   },
   "browserslist": {
     "production": [


### PR DESCRIPTION
Forgot to push these changes.
This should close some dependabot PRs that won't work since the dependencies need to be updated together.