### PR TITLE
chore: Bump docusaurus versions

### DIFF
--- a/.github/workflows/deploy-review-app.yml
+++ b/.github/workflows/deploy-review-app.yml
@@ -10,8 +10,8 @@ jobs:
     name: Build Review App
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: 18
           cache: npm
@@ -24,7 +24,7 @@ jobs:
 
       - name: Build web
         run: npm run build
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: web
           path: build

--- a/i18n/de/docusaurus-plugin-content-docs/current/help-center/using-famedly/login.mdx
+++ b/i18n/de/docusaurus-plugin-content-docs/current/help-center/using-famedly/login.mdx
@@ -46,7 +46,7 @@ import useBaseUrl from '@docusaurus/useBaseUrl';
 Nach dem Login werden Sie zu einer Seite mit verschiedenen Schaltern für <b>Datenschutzeinstellungen</b> (Chat-Features) und für das <b>Benutzerverzeichnis</b> weitergeleitet. 
 
 Eine Beschreibung zu den Chat-Features finden Sie hier: [Datenschutzeinstellungen](../your-account/account-settings#datenschutz)  
-Informationen zur Einstellung zum Benutzerverzeichnis finden Sie hier: [Verzeichnis](../your-account/account-settings#Verzeichnis)
+Informationen zur Einstellung zum Benutzerverzeichnis finden Sie hier: [Verzeichnis](../your-account/account-settings#verzeichnis)
 
 Falls Sie bereits das [Chat-Backup](../first-steps/first-login#chat-backup-aktivieren) aktiviert haben, werden Sie nun zum Verifikationsprozess weitergeleitet, wenn Sie auf <b>Fortfahren</b> klicken. 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,8 @@
       "version": "0.1.0",
       "dependencies": {
         "@crowdin/cli": "^3.14.0",
-        "@docusaurus/core": "3.0.1",
-        "@docusaurus/preset-classic": "3.0.1",
+        "@docusaurus/core": "3.1.1",
+        "@docusaurus/preset-classic": "3.1.1",
         "@mdx-js/react": "^3.0.0",
         "autoprefixer": "^10.4.14",
         "clsx": "^2.0.0",
@@ -20,7 +20,7 @@
         "react-dom": "^18.2.0"
       },
       "devDependencies": {
-        "@docusaurus/module-type-aliases": "3.0.1"
+        "@docusaurus/module-type-aliases": "3.1.1"
       },
       "engines": {
         "node": ">=18.0"
@@ -68,74 +68,74 @@
       }
     },
     "node_modules/@algolia/cache-browser-local-storage": {
-      "version": "4.22.0",
-      "resolved": "https://registry.npmjs.org/@algolia/cache-browser-local-storage/-/cache-browser-local-storage-4.22.0.tgz",
-      "integrity": "sha512-uZ1uZMLDZb4qODLfTSNHxSi4fH9RdrQf7DXEzW01dS8XK7QFtFh29N5NGKa9S+Yudf1vUMIF+/RiL4i/J0pWlQ==",
+      "version": "4.22.1",
+      "resolved": "https://registry.npmjs.org/@algolia/cache-browser-local-storage/-/cache-browser-local-storage-4.22.1.tgz",
+      "integrity": "sha512-Sw6IAmOCvvP6QNgY9j+Hv09mvkvEIDKjYW8ow0UDDAxSXy664RBNQk3i/0nt7gvceOJ6jGmOTimaZoY1THmU7g==",
       "dependencies": {
-        "@algolia/cache-common": "4.22.0"
+        "@algolia/cache-common": "4.22.1"
       }
     },
     "node_modules/@algolia/cache-common": {
-      "version": "4.22.0",
-      "resolved": "https://registry.npmjs.org/@algolia/cache-common/-/cache-common-4.22.0.tgz",
-      "integrity": "sha512-TPwUMlIGPN16eW67qamNQUmxNiGHg/WBqWcrOoCddhqNTqGDPVqmgfaM85LPbt24t3r1z0zEz/tdsmuq3Q6oaA=="
+      "version": "4.22.1",
+      "resolved": "https://registry.npmjs.org/@algolia/cache-common/-/cache-common-4.22.1.tgz",
+      "integrity": "sha512-TJMBKqZNKYB9TptRRjSUtevJeQVXRmg6rk9qgFKWvOy8jhCPdyNZV1nB3SKGufzvTVbomAukFR8guu/8NRKBTA=="
     },
     "node_modules/@algolia/cache-in-memory": {
-      "version": "4.22.0",
-      "resolved": "https://registry.npmjs.org/@algolia/cache-in-memory/-/cache-in-memory-4.22.0.tgz",
-      "integrity": "sha512-kf4Cio9NpPjzp1+uXQgL4jsMDeck7MP89BYThSvXSjf2A6qV/0KeqQf90TL2ECS02ovLOBXkk98P7qVarM+zGA==",
+      "version": "4.22.1",
+      "resolved": "https://registry.npmjs.org/@algolia/cache-in-memory/-/cache-in-memory-4.22.1.tgz",
+      "integrity": "sha512-ve+6Ac2LhwpufuWavM/aHjLoNz/Z/sYSgNIXsinGofWOysPilQZPUetqLj8vbvi+DHZZaYSEP9H5SRVXnpsNNw==",
       "dependencies": {
-        "@algolia/cache-common": "4.22.0"
+        "@algolia/cache-common": "4.22.1"
       }
     },
     "node_modules/@algolia/client-account": {
-      "version": "4.22.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-account/-/client-account-4.22.0.tgz",
-      "integrity": "sha512-Bjb5UXpWmJT+yGWiqAJL0prkENyEZTBzdC+N1vBuHjwIJcjLMjPB6j1hNBRbT12Lmwi55uzqeMIKS69w+0aPzA==",
+      "version": "4.22.1",
+      "resolved": "https://registry.npmjs.org/@algolia/client-account/-/client-account-4.22.1.tgz",
+      "integrity": "sha512-k8m+oegM2zlns/TwZyi4YgCtyToackkOpE+xCaKCYfBfDtdGOaVZCM5YvGPtK+HGaJMIN/DoTL8asbM3NzHonw==",
       "dependencies": {
-        "@algolia/client-common": "4.22.0",
-        "@algolia/client-search": "4.22.0",
-        "@algolia/transporter": "4.22.0"
+        "@algolia/client-common": "4.22.1",
+        "@algolia/client-search": "4.22.1",
+        "@algolia/transporter": "4.22.1"
       }
     },
     "node_modules/@algolia/client-analytics": {
-      "version": "4.22.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-4.22.0.tgz",
-      "integrity": "sha512-os2K+kHUcwwRa4ArFl5p/3YbF9lN3TLOPkbXXXxOvDpqFh62n9IRZuzfxpHxMPKAQS3Et1s0BkKavnNP02E9Hg==",
+      "version": "4.22.1",
+      "resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-4.22.1.tgz",
+      "integrity": "sha512-1ssi9pyxyQNN4a7Ji9R50nSdISIumMFDwKNuwZipB6TkauJ8J7ha/uO60sPJFqQyqvvI+px7RSNRQT3Zrvzieg==",
       "dependencies": {
-        "@algolia/client-common": "4.22.0",
-        "@algolia/client-search": "4.22.0",
-        "@algolia/requester-common": "4.22.0",
-        "@algolia/transporter": "4.22.0"
+        "@algolia/client-common": "4.22.1",
+        "@algolia/client-search": "4.22.1",
+        "@algolia/requester-common": "4.22.1",
+        "@algolia/transporter": "4.22.1"
       }
     },
     "node_modules/@algolia/client-common": {
-      "version": "4.22.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-4.22.0.tgz",
-      "integrity": "sha512-BlbkF4qXVWuwTmYxVWvqtatCR3lzXwxx628p1wj1Q7QP2+LsTmGt1DiUYRuy9jG7iMsnlExby6kRMOOlbhv2Ag==",
+      "version": "4.22.1",
+      "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-4.22.1.tgz",
+      "integrity": "sha512-IvaL5v9mZtm4k4QHbBGDmU3wa/mKokmqNBqPj0K7lcR8ZDKzUorhcGp/u8PkPC/e0zoHSTvRh7TRkGX3Lm7iOQ==",
       "dependencies": {
-        "@algolia/requester-common": "4.22.0",
-        "@algolia/transporter": "4.22.0"
+        "@algolia/requester-common": "4.22.1",
+        "@algolia/transporter": "4.22.1"
       }
     },
     "node_modules/@algolia/client-personalization": {
-      "version": "4.22.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-personalization/-/client-personalization-4.22.0.tgz",
-      "integrity": "sha512-pEOftCxeBdG5pL97WngOBi9w5Vxr5KCV2j2D+xMVZH8MuU/JX7CglDSDDb0ffQWYqcUN+40Ry+xtXEYaGXTGow==",
+      "version": "4.22.1",
+      "resolved": "https://registry.npmjs.org/@algolia/client-personalization/-/client-personalization-4.22.1.tgz",
+      "integrity": "sha512-sl+/klQJ93+4yaqZ7ezOttMQ/nczly/3GmgZXJ1xmoewP5jmdP/X/nV5U7EHHH3hCUEHeN7X1nsIhGPVt9E1cQ==",
       "dependencies": {
-        "@algolia/client-common": "4.22.0",
-        "@algolia/requester-common": "4.22.0",
-        "@algolia/transporter": "4.22.0"
+        "@algolia/client-common": "4.22.1",
+        "@algolia/requester-common": "4.22.1",
+        "@algolia/transporter": "4.22.1"
       }
     },
     "node_modules/@algolia/client-search": {
-      "version": "4.22.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-4.22.0.tgz",
-      "integrity": "sha512-bn4qQiIdRPBGCwsNuuqB8rdHhGKKWIij9OqidM1UkQxnSG8yzxHdb7CujM30pvp5EnV7jTqDZRbxacbjYVW20Q==",
+      "version": "4.22.1",
+      "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-4.22.1.tgz",
+      "integrity": "sha512-yb05NA4tNaOgx3+rOxAmFztgMTtGBi97X7PC3jyNeGiwkAjOZc2QrdZBYyIdcDLoI09N0gjtpClcackoTN0gPA==",
       "dependencies": {
-        "@algolia/client-common": "4.22.0",
-        "@algolia/requester-common": "4.22.0",
-        "@algolia/transporter": "4.22.0"
+        "@algolia/client-common": "4.22.1",
+        "@algolia/requester-common": "4.22.1",
+        "@algolia/transporter": "4.22.1"
       }
     },
     "node_modules/@algolia/events": {
@@ -144,47 +144,47 @@
       "integrity": "sha512-FQzvOCgoFXAbf5Y6mYozw2aj5KCJoA3m4heImceldzPSMbdyS4atVjJzXKMsfX3wnZTFYwkkt8/z8UesLHlSBQ=="
     },
     "node_modules/@algolia/logger-common": {
-      "version": "4.22.0",
-      "resolved": "https://registry.npmjs.org/@algolia/logger-common/-/logger-common-4.22.0.tgz",
-      "integrity": "sha512-HMUQTID0ucxNCXs5d1eBJ5q/HuKg8rFVE/vOiLaM4Abfeq1YnTtGV3+rFEhOPWhRQxNDd+YHa4q864IMc0zHpQ=="
+      "version": "4.22.1",
+      "resolved": "https://registry.npmjs.org/@algolia/logger-common/-/logger-common-4.22.1.tgz",
+      "integrity": "sha512-OnTFymd2odHSO39r4DSWRFETkBufnY2iGUZNrMXpIhF5cmFE8pGoINNPzwg02QLBlGSaLqdKy0bM8S0GyqPLBg=="
     },
     "node_modules/@algolia/logger-console": {
-      "version": "4.22.0",
-      "resolved": "https://registry.npmjs.org/@algolia/logger-console/-/logger-console-4.22.0.tgz",
-      "integrity": "sha512-7JKb6hgcY64H7CRm3u6DRAiiEVXMvCJV5gRE672QFOUgDxo4aiDpfU61g6Uzy8NKjlEzHMmgG4e2fklELmPXhQ==",
+      "version": "4.22.1",
+      "resolved": "https://registry.npmjs.org/@algolia/logger-console/-/logger-console-4.22.1.tgz",
+      "integrity": "sha512-O99rcqpVPKN1RlpgD6H3khUWylU24OXlzkavUAMy6QZd1776QAcauE3oP8CmD43nbaTjBexZj2nGsBH9Tc0FVA==",
       "dependencies": {
-        "@algolia/logger-common": "4.22.0"
+        "@algolia/logger-common": "4.22.1"
       }
     },
     "node_modules/@algolia/requester-browser-xhr": {
-      "version": "4.22.0",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-4.22.0.tgz",
-      "integrity": "sha512-BHfv1h7P9/SyvcDJDaRuIwDu2yrDLlXlYmjvaLZTtPw6Ok/ZVhBR55JqW832XN/Fsl6k3LjdkYHHR7xnsa5Wvg==",
+      "version": "4.22.1",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-4.22.1.tgz",
+      "integrity": "sha512-dtQGYIg6MteqT1Uay3J/0NDqD+UciHy3QgRbk7bNddOJu+p3hzjTRYESqEnoX/DpEkaNYdRHUKNylsqMpgwaEw==",
       "dependencies": {
-        "@algolia/requester-common": "4.22.0"
+        "@algolia/requester-common": "4.22.1"
       }
     },
     "node_modules/@algolia/requester-common": {
-      "version": "4.22.0",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-common/-/requester-common-4.22.0.tgz",
-      "integrity": "sha512-Y9cEH/cKjIIZgzvI1aI0ARdtR/xRrOR13g5psCxkdhpgRN0Vcorx+zePhmAa4jdQNqexpxtkUdcKYugBzMZJgQ=="
+      "version": "4.22.1",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-common/-/requester-common-4.22.1.tgz",
+      "integrity": "sha512-dgvhSAtg2MJnR+BxrIFqlLtkLlVVhas9HgYKMk2Uxiy5m6/8HZBL40JVAMb2LovoPFs9I/EWIoFVjOrFwzn5Qg=="
     },
     "node_modules/@algolia/requester-node-http": {
-      "version": "4.22.0",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-4.22.0.tgz",
-      "integrity": "sha512-8xHoGpxVhz3u2MYIieHIB6MsnX+vfd5PS4REgglejJ6lPigftRhTdBCToe6zbwq4p0anZXjjPDvNWMlgK2+xYA==",
+      "version": "4.22.1",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-4.22.1.tgz",
+      "integrity": "sha512-JfmZ3MVFQkAU+zug8H3s8rZ6h0ahHZL/SpMaSasTCGYR5EEJsCc8SI5UZ6raPN2tjxa5bxS13BRpGSBUens7EA==",
       "dependencies": {
-        "@algolia/requester-common": "4.22.0"
+        "@algolia/requester-common": "4.22.1"
       }
     },
     "node_modules/@algolia/transporter": {
-      "version": "4.22.0",
-      "resolved": "https://registry.npmjs.org/@algolia/transporter/-/transporter-4.22.0.tgz",
-      "integrity": "sha512-ieO1k8x2o77GNvOoC+vAkFKppydQSVfbjM3YrSjLmgywiBejPTvU1R1nEvG59JIIUvtSLrZsLGPkd6vL14zopA==",
+      "version": "4.22.1",
+      "resolved": "https://registry.npmjs.org/@algolia/transporter/-/transporter-4.22.1.tgz",
+      "integrity": "sha512-kzWgc2c9IdxMa3YqA6TN0NW5VrKYYW/BELIn7vnLyn+U/RFdZ4lxxt9/8yq3DKV5snvoDzzO4ClyejZRdV3lMQ==",
       "dependencies": {
-        "@algolia/cache-common": "4.22.0",
-        "@algolia/logger-common": "4.22.0",
-        "@algolia/requester-common": "4.22.0"
+        "@algolia/cache-common": "4.22.1",
+        "@algolia/logger-common": "4.22.1",
+        "@algolia/requester-common": "4.22.1"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -2180,9 +2180,9 @@
       }
     },
     "node_modules/@docusaurus/core": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-3.0.1.tgz",
-      "integrity": "sha512-CXrLpOnW+dJdSv8M5FAJ3JBwXtL6mhUWxFA8aS0ozK6jBG/wgxERk5uvH28fCeFxOGbAT9v1e9dOMo1X2IEVhQ==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-3.1.1.tgz",
+      "integrity": "sha512-2nQfKFcf+MLEM7JXsXwQxPOmQAR6ytKMZVSx7tVi9HEm9WtfwBH1fp6bn8Gj4zLUhjWKCLoysQ9/Wm+EZCQ4yQ==",
       "dependencies": {
         "@babel/core": "^7.23.3",
         "@babel/generator": "^7.23.3",
@@ -2194,13 +2194,13 @@
         "@babel/runtime": "^7.22.6",
         "@babel/runtime-corejs3": "^7.22.6",
         "@babel/traverse": "^7.22.8",
-        "@docusaurus/cssnano-preset": "3.0.1",
-        "@docusaurus/logger": "3.0.1",
-        "@docusaurus/mdx-loader": "3.0.1",
+        "@docusaurus/cssnano-preset": "3.1.1",
+        "@docusaurus/logger": "3.1.1",
+        "@docusaurus/mdx-loader": "3.1.1",
         "@docusaurus/react-loadable": "5.5.2",
-        "@docusaurus/utils": "3.0.1",
-        "@docusaurus/utils-common": "3.0.1",
-        "@docusaurus/utils-validation": "3.0.1",
+        "@docusaurus/utils": "3.1.1",
+        "@docusaurus/utils-common": "3.1.1",
+        "@docusaurus/utils-validation": "3.1.1",
         "@slorber/static-site-generator-webpack-plugin": "^4.0.7",
         "@svgr/webpack": "^6.5.1",
         "autoprefixer": "^10.4.14",
@@ -2266,9 +2266,9 @@
       }
     },
     "node_modules/@docusaurus/cssnano-preset": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/cssnano-preset/-/cssnano-preset-3.0.1.tgz",
-      "integrity": "sha512-wjuXzkHMW+ig4BD6Ya1Yevx9UJadO4smNZCEljqBoQfIQrQskTswBs7lZ8InHP7mCt273a/y/rm36EZhqJhknQ==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/cssnano-preset/-/cssnano-preset-3.1.1.tgz",
+      "integrity": "sha512-LnoIDjJWbirdbVZDMq+4hwmrTl2yHDnBf9MLG9qyExeAE3ac35s4yUhJI8yyTCdixzNfKit4cbXblzzqMu4+8g==",
       "dependencies": {
         "cssnano-preset-advanced": "^5.3.10",
         "postcss": "^8.4.26",
@@ -2280,9 +2280,9 @@
       }
     },
     "node_modules/@docusaurus/logger": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/logger/-/logger-3.0.1.tgz",
-      "integrity": "sha512-I5L6Nk8OJzkVA91O2uftmo71LBSxe1vmOn9AMR6JRCzYeEBrqneWMH02AqMvjJ2NpMiviO+t0CyPjyYV7nxCWQ==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/logger/-/logger-3.1.1.tgz",
+      "integrity": "sha512-BjkNDpQzewcTnST8trx4idSoAla6zZ3w22NqM/UMcFtvYJgmoE4layuTzlfql3VFPNuivvj7BOExa/+21y4X2Q==",
       "dependencies": {
         "chalk": "^4.1.2",
         "tslib": "^2.6.0"
@@ -2292,15 +2292,15 @@
       }
     },
     "node_modules/@docusaurus/mdx-loader": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/mdx-loader/-/mdx-loader-3.0.1.tgz",
-      "integrity": "sha512-ldnTmvnvlrONUq45oKESrpy+lXtbnTcTsFkOTIDswe5xx5iWJjt6eSa0f99ZaWlnm24mlojcIGoUWNCS53qVlQ==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/mdx-loader/-/mdx-loader-3.1.1.tgz",
+      "integrity": "sha512-xN2IccH9+sv7TmxwsDJNS97BHdmlqWwho+kIVY4tcCXkp+k4QuzvWBeunIMzeayY4Fu13A6sAjHGv5qm72KyGA==",
       "dependencies": {
         "@babel/parser": "^7.22.7",
         "@babel/traverse": "^7.22.8",
-        "@docusaurus/logger": "3.0.1",
-        "@docusaurus/utils": "3.0.1",
-        "@docusaurus/utils-validation": "3.0.1",
+        "@docusaurus/logger": "3.1.1",
+        "@docusaurus/utils": "3.1.1",
+        "@docusaurus/utils-validation": "3.1.1",
         "@mdx-js/mdx": "^3.0.0",
         "@slorber/remark-comment": "^1.0.0",
         "escape-html": "^1.0.3",
@@ -2332,12 +2332,12 @@
       }
     },
     "node_modules/@docusaurus/module-type-aliases": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/module-type-aliases/-/module-type-aliases-3.0.1.tgz",
-      "integrity": "sha512-DEHpeqUDsLynl3AhQQiO7AbC7/z/lBra34jTcdYuvp9eGm01pfH1wTVq8YqWZq6Jyx0BgcVl/VJqtE9StRd9Ag==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/module-type-aliases/-/module-type-aliases-3.1.1.tgz",
+      "integrity": "sha512-xBJyx0TMfAfVZ9ZeIOb1awdXgR4YJMocIEzTps91rq+hJDFJgJaylDtmoRhUxkwuYmNK1GJpW95b7DLztSBJ3A==",
       "dependencies": {
         "@docusaurus/react-loadable": "5.5.2",
-        "@docusaurus/types": "3.0.1",
+        "@docusaurus/types": "3.1.1",
         "@types/history": "^4.7.11",
         "@types/react": "*",
         "@types/react-router-config": "*",
@@ -2351,17 +2351,17 @@
       }
     },
     "node_modules/@docusaurus/plugin-content-blog": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-blog/-/plugin-content-blog-3.0.1.tgz",
-      "integrity": "sha512-cLOvtvAyaMQFLI8vm4j26svg3ktxMPSXpuUJ7EERKoGbfpJSsgtowNHcRsaBVmfuCsRSk1HZ/yHBsUkTmHFEsg==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-blog/-/plugin-content-blog-3.1.1.tgz",
+      "integrity": "sha512-ew/3VtVoG3emoAKmoZl7oKe1zdFOsI0NbcHS26kIxt2Z8vcXKCUgK9jJJrz0TbOipyETPhqwq4nbitrY3baibg==",
       "dependencies": {
-        "@docusaurus/core": "3.0.1",
-        "@docusaurus/logger": "3.0.1",
-        "@docusaurus/mdx-loader": "3.0.1",
-        "@docusaurus/types": "3.0.1",
-        "@docusaurus/utils": "3.0.1",
-        "@docusaurus/utils-common": "3.0.1",
-        "@docusaurus/utils-validation": "3.0.1",
+        "@docusaurus/core": "3.1.1",
+        "@docusaurus/logger": "3.1.1",
+        "@docusaurus/mdx-loader": "3.1.1",
+        "@docusaurus/types": "3.1.1",
+        "@docusaurus/utils": "3.1.1",
+        "@docusaurus/utils-common": "3.1.1",
+        "@docusaurus/utils-validation": "3.1.1",
         "cheerio": "^1.0.0-rc.12",
         "feed": "^4.2.2",
         "fs-extra": "^11.1.1",
@@ -2382,17 +2382,17 @@
       }
     },
     "node_modules/@docusaurus/plugin-content-docs": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-docs/-/plugin-content-docs-3.0.1.tgz",
-      "integrity": "sha512-dRfAOA5Ivo+sdzzJGXEu33yAtvGg8dlZkvt/NEJ7nwi1F2j4LEdsxtfX2GKeETB2fP6XoGNSQnFXqa2NYGrHFg==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-docs/-/plugin-content-docs-3.1.1.tgz",
+      "integrity": "sha512-lhFq4E874zw0UOH7ujzxnCayOyAt0f9YPVYSb9ohxrdCM8B4szxitUw9rIX4V9JLLHVoqIJb6k+lJJ1jrcGJ0A==",
       "dependencies": {
-        "@docusaurus/core": "3.0.1",
-        "@docusaurus/logger": "3.0.1",
-        "@docusaurus/mdx-loader": "3.0.1",
-        "@docusaurus/module-type-aliases": "3.0.1",
-        "@docusaurus/types": "3.0.1",
-        "@docusaurus/utils": "3.0.1",
-        "@docusaurus/utils-validation": "3.0.1",
+        "@docusaurus/core": "3.1.1",
+        "@docusaurus/logger": "3.1.1",
+        "@docusaurus/mdx-loader": "3.1.1",
+        "@docusaurus/module-type-aliases": "3.1.1",
+        "@docusaurus/types": "3.1.1",
+        "@docusaurus/utils": "3.1.1",
+        "@docusaurus/utils-validation": "3.1.1",
         "@types/react-router-config": "^5.0.7",
         "combine-promises": "^1.1.0",
         "fs-extra": "^11.1.1",
@@ -2411,15 +2411,15 @@
       }
     },
     "node_modules/@docusaurus/plugin-content-pages": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-pages/-/plugin-content-pages-3.0.1.tgz",
-      "integrity": "sha512-oP7PoYizKAXyEttcvVzfX3OoBIXEmXTMzCdfmC4oSwjG4SPcJsRge3mmI6O8jcZBgUPjIzXD21bVGWEE1iu8gg==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-pages/-/plugin-content-pages-3.1.1.tgz",
+      "integrity": "sha512-NQHncNRAJbyLtgTim9GlEnNYsFhuCxaCNkMwikuxLTiGIPH7r/jpb7O3f3jUMYMebZZZrDq5S7om9a6rvB/YCA==",
       "dependencies": {
-        "@docusaurus/core": "3.0.1",
-        "@docusaurus/mdx-loader": "3.0.1",
-        "@docusaurus/types": "3.0.1",
-        "@docusaurus/utils": "3.0.1",
-        "@docusaurus/utils-validation": "3.0.1",
+        "@docusaurus/core": "3.1.1",
+        "@docusaurus/mdx-loader": "3.1.1",
+        "@docusaurus/types": "3.1.1",
+        "@docusaurus/utils": "3.1.1",
+        "@docusaurus/utils-validation": "3.1.1",
         "fs-extra": "^11.1.1",
         "tslib": "^2.6.0",
         "webpack": "^5.88.1"
@@ -2433,13 +2433,13 @@
       }
     },
     "node_modules/@docusaurus/plugin-debug": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-debug/-/plugin-debug-3.0.1.tgz",
-      "integrity": "sha512-09dxZMdATky4qdsZGzhzlUvvC+ilQ2hKbYF+wez+cM2mGo4qHbv8+qKXqxq0CQZyimwlAOWQLoSozIXU0g0i7g==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-debug/-/plugin-debug-3.1.1.tgz",
+      "integrity": "sha512-xWeMkueM9wE/8LVvl4+Qf1WqwXmreMjI5Kgr7GYCDoJ8zu4kD+KaMhrh7py7MNM38IFvU1RfrGKacCEe2DRRfQ==",
       "dependencies": {
-        "@docusaurus/core": "3.0.1",
-        "@docusaurus/types": "3.0.1",
-        "@docusaurus/utils": "3.0.1",
+        "@docusaurus/core": "3.1.1",
+        "@docusaurus/types": "3.1.1",
+        "@docusaurus/utils": "3.1.1",
         "fs-extra": "^11.1.1",
         "react-json-view-lite": "^1.2.0",
         "tslib": "^2.6.0"
@@ -2453,13 +2453,13 @@
       }
     },
     "node_modules/@docusaurus/plugin-google-analytics": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-analytics/-/plugin-google-analytics-3.0.1.tgz",
-      "integrity": "sha512-jwseSz1E+g9rXQwDdr0ZdYNjn8leZBnKPjjQhMBEiwDoenL3JYFcNW0+p0sWoVF/f2z5t7HkKA+cYObrUh18gg==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-analytics/-/plugin-google-analytics-3.1.1.tgz",
+      "integrity": "sha512-+q2UpWTqVi8GdlLoSlD5bS/YpxW+QMoBwrPrUH/NpvpuOi0Of7MTotsQf9JWd3hymZxl2uu1o3PIrbpxfeDFDQ==",
       "dependencies": {
-        "@docusaurus/core": "3.0.1",
-        "@docusaurus/types": "3.0.1",
-        "@docusaurus/utils-validation": "3.0.1",
+        "@docusaurus/core": "3.1.1",
+        "@docusaurus/types": "3.1.1",
+        "@docusaurus/utils-validation": "3.1.1",
         "tslib": "^2.6.0"
       },
       "engines": {
@@ -2471,13 +2471,13 @@
       }
     },
     "node_modules/@docusaurus/plugin-google-gtag": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-gtag/-/plugin-google-gtag-3.0.1.tgz",
-      "integrity": "sha512-UFTDvXniAWrajsulKUJ1DB6qplui1BlKLQZjX4F7qS/qfJ+qkKqSkhJ/F4VuGQ2JYeZstYb+KaUzUzvaPK1aRQ==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-gtag/-/plugin-google-gtag-3.1.1.tgz",
+      "integrity": "sha512-0mMPiBBlQ5LFHTtjxuvt/6yzh8v7OxLi3CbeEsxXZpUzcKO/GC7UA1VOWUoBeQzQL508J12HTAlR3IBU9OofSw==",
       "dependencies": {
-        "@docusaurus/core": "3.0.1",
-        "@docusaurus/types": "3.0.1",
-        "@docusaurus/utils-validation": "3.0.1",
+        "@docusaurus/core": "3.1.1",
+        "@docusaurus/types": "3.1.1",
+        "@docusaurus/utils-validation": "3.1.1",
         "@types/gtag.js": "^0.0.12",
         "tslib": "^2.6.0"
       },
@@ -2490,13 +2490,13 @@
       }
     },
     "node_modules/@docusaurus/plugin-google-tag-manager": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-tag-manager/-/plugin-google-tag-manager-3.0.1.tgz",
-      "integrity": "sha512-IPFvuz83aFuheZcWpTlAdiiX1RqWIHM+OH8wS66JgwAKOiQMR3+nLywGjkLV4bp52x7nCnwhNk1rE85Cpy/CIw==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-tag-manager/-/plugin-google-tag-manager-3.1.1.tgz",
+      "integrity": "sha512-d07bsrMLdDIryDtY17DgqYUbjkswZQr8cLWl4tzXrt5OR/T/zxC1SYKajzB3fd87zTu5W5klV5GmUwcNSMXQXA==",
       "dependencies": {
-        "@docusaurus/core": "3.0.1",
-        "@docusaurus/types": "3.0.1",
-        "@docusaurus/utils-validation": "3.0.1",
+        "@docusaurus/core": "3.1.1",
+        "@docusaurus/types": "3.1.1",
+        "@docusaurus/utils-validation": "3.1.1",
         "tslib": "^2.6.0"
       },
       "engines": {
@@ -2508,16 +2508,16 @@
       }
     },
     "node_modules/@docusaurus/plugin-sitemap": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-sitemap/-/plugin-sitemap-3.0.1.tgz",
-      "integrity": "sha512-xARiWnjtVvoEniZudlCq5T9ifnhCu/GAZ5nA7XgyLfPcNpHQa241HZdsTlLtVcecEVVdllevBKOp7qknBBaMGw==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-sitemap/-/plugin-sitemap-3.1.1.tgz",
+      "integrity": "sha512-iJ4hCaMmDaUqRv131XJdt/C/jJQx8UreDWTRqZKtNydvZVh/o4yXGRRFOplea1D9b/zpwL1Y+ZDwX7xMhIOTmg==",
       "dependencies": {
-        "@docusaurus/core": "3.0.1",
-        "@docusaurus/logger": "3.0.1",
-        "@docusaurus/types": "3.0.1",
-        "@docusaurus/utils": "3.0.1",
-        "@docusaurus/utils-common": "3.0.1",
-        "@docusaurus/utils-validation": "3.0.1",
+        "@docusaurus/core": "3.1.1",
+        "@docusaurus/logger": "3.1.1",
+        "@docusaurus/types": "3.1.1",
+        "@docusaurus/utils": "3.1.1",
+        "@docusaurus/utils-common": "3.1.1",
+        "@docusaurus/utils-validation": "3.1.1",
         "fs-extra": "^11.1.1",
         "sitemap": "^7.1.1",
         "tslib": "^2.6.0"
@@ -2531,23 +2531,23 @@
       }
     },
     "node_modules/@docusaurus/preset-classic": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/preset-classic/-/preset-classic-3.0.1.tgz",
-      "integrity": "sha512-il9m9xZKKjoXn6h0cRcdnt6wce0Pv1y5t4xk2Wx7zBGhKG1idu4IFHtikHlD0QPuZ9fizpXspXcTzjL5FXc1Gw==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/preset-classic/-/preset-classic-3.1.1.tgz",
+      "integrity": "sha512-jG4ys/hWYf69iaN/xOmF+3kjs4Nnz1Ay3CjFLDtYa8KdxbmUhArA9HmP26ru5N0wbVWhY+6kmpYhTJpez5wTyg==",
       "dependencies": {
-        "@docusaurus/core": "3.0.1",
-        "@docusaurus/plugin-content-blog": "3.0.1",
-        "@docusaurus/plugin-content-docs": "3.0.1",
-        "@docusaurus/plugin-content-pages": "3.0.1",
-        "@docusaurus/plugin-debug": "3.0.1",
-        "@docusaurus/plugin-google-analytics": "3.0.1",
-        "@docusaurus/plugin-google-gtag": "3.0.1",
-        "@docusaurus/plugin-google-tag-manager": "3.0.1",
-        "@docusaurus/plugin-sitemap": "3.0.1",
-        "@docusaurus/theme-classic": "3.0.1",
-        "@docusaurus/theme-common": "3.0.1",
-        "@docusaurus/theme-search-algolia": "3.0.1",
-        "@docusaurus/types": "3.0.1"
+        "@docusaurus/core": "3.1.1",
+        "@docusaurus/plugin-content-blog": "3.1.1",
+        "@docusaurus/plugin-content-docs": "3.1.1",
+        "@docusaurus/plugin-content-pages": "3.1.1",
+        "@docusaurus/plugin-debug": "3.1.1",
+        "@docusaurus/plugin-google-analytics": "3.1.1",
+        "@docusaurus/plugin-google-gtag": "3.1.1",
+        "@docusaurus/plugin-google-tag-manager": "3.1.1",
+        "@docusaurus/plugin-sitemap": "3.1.1",
+        "@docusaurus/theme-classic": "3.1.1",
+        "@docusaurus/theme-common": "3.1.1",
+        "@docusaurus/theme-search-algolia": "3.1.1",
+        "@docusaurus/types": "3.1.1"
       },
       "engines": {
         "node": ">=18.0"
@@ -2570,22 +2570,22 @@
       }
     },
     "node_modules/@docusaurus/theme-classic": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-classic/-/theme-classic-3.0.1.tgz",
-      "integrity": "sha512-XD1FRXaJiDlmYaiHHdm27PNhhPboUah9rqIH0lMpBt5kYtsGjJzhqa27KuZvHLzOP2OEpqd2+GZ5b6YPq7Q05Q==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-classic/-/theme-classic-3.1.1.tgz",
+      "integrity": "sha512-GiPE/jbWM8Qv1A14lk6s9fhc0LhPEQ00eIczRO4QL2nAQJZXkjPG6zaVx+1cZxPFWbAsqSjKe2lqkwF3fGkQ7Q==",
       "dependencies": {
-        "@docusaurus/core": "3.0.1",
-        "@docusaurus/mdx-loader": "3.0.1",
-        "@docusaurus/module-type-aliases": "3.0.1",
-        "@docusaurus/plugin-content-blog": "3.0.1",
-        "@docusaurus/plugin-content-docs": "3.0.1",
-        "@docusaurus/plugin-content-pages": "3.0.1",
-        "@docusaurus/theme-common": "3.0.1",
-        "@docusaurus/theme-translations": "3.0.1",
-        "@docusaurus/types": "3.0.1",
-        "@docusaurus/utils": "3.0.1",
-        "@docusaurus/utils-common": "3.0.1",
-        "@docusaurus/utils-validation": "3.0.1",
+        "@docusaurus/core": "3.1.1",
+        "@docusaurus/mdx-loader": "3.1.1",
+        "@docusaurus/module-type-aliases": "3.1.1",
+        "@docusaurus/plugin-content-blog": "3.1.1",
+        "@docusaurus/plugin-content-docs": "3.1.1",
+        "@docusaurus/plugin-content-pages": "3.1.1",
+        "@docusaurus/theme-common": "3.1.1",
+        "@docusaurus/theme-translations": "3.1.1",
+        "@docusaurus/types": "3.1.1",
+        "@docusaurus/utils": "3.1.1",
+        "@docusaurus/utils-common": "3.1.1",
+        "@docusaurus/utils-validation": "3.1.1",
         "@mdx-js/react": "^3.0.0",
         "clsx": "^2.0.0",
         "copy-text-to-clipboard": "^3.2.0",
@@ -2609,17 +2609,17 @@
       }
     },
     "node_modules/@docusaurus/theme-common": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-common/-/theme-common-3.0.1.tgz",
-      "integrity": "sha512-cr9TOWXuIOL0PUfuXv6L5lPlTgaphKP+22NdVBOYah5jSq5XAAulJTjfe+IfLsEG4L7lJttLbhW7LXDFSAI7Ag==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-common/-/theme-common-3.1.1.tgz",
+      "integrity": "sha512-38urZfeMhN70YaXkwIGXmcUcv2CEYK/2l4b05GkJPrbEbgpsIZM3Xc+Js2ehBGGZmfZq8GjjQ5RNQYG+MYzCYg==",
       "dependencies": {
-        "@docusaurus/mdx-loader": "3.0.1",
-        "@docusaurus/module-type-aliases": "3.0.1",
-        "@docusaurus/plugin-content-blog": "3.0.1",
-        "@docusaurus/plugin-content-docs": "3.0.1",
-        "@docusaurus/plugin-content-pages": "3.0.1",
-        "@docusaurus/utils": "3.0.1",
-        "@docusaurus/utils-common": "3.0.1",
+        "@docusaurus/mdx-loader": "3.1.1",
+        "@docusaurus/module-type-aliases": "3.1.1",
+        "@docusaurus/plugin-content-blog": "3.1.1",
+        "@docusaurus/plugin-content-docs": "3.1.1",
+        "@docusaurus/plugin-content-pages": "3.1.1",
+        "@docusaurus/utils": "3.1.1",
+        "@docusaurus/utils-common": "3.1.1",
         "@types/history": "^4.7.11",
         "@types/react": "*",
         "@types/react-router-config": "*",
@@ -2638,18 +2638,18 @@
       }
     },
     "node_modules/@docusaurus/theme-search-algolia": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-search-algolia/-/theme-search-algolia-3.0.1.tgz",
-      "integrity": "sha512-DDiPc0/xmKSEdwFkXNf1/vH1SzJPzuJBar8kMcBbDAZk/SAmo/4lf6GU2drou4Ae60lN2waix+jYWTWcJRahSA==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-search-algolia/-/theme-search-algolia-3.1.1.tgz",
+      "integrity": "sha512-tBH9VY5EpRctVdaAhT+b1BY8y5dyHVZGFXyCHgTrvcXQy5CV4q7serEX7U3SveNT9zksmchPyct6i1sFDC4Z5g==",
       "dependencies": {
         "@docsearch/react": "^3.5.2",
-        "@docusaurus/core": "3.0.1",
-        "@docusaurus/logger": "3.0.1",
-        "@docusaurus/plugin-content-docs": "3.0.1",
-        "@docusaurus/theme-common": "3.0.1",
-        "@docusaurus/theme-translations": "3.0.1",
-        "@docusaurus/utils": "3.0.1",
-        "@docusaurus/utils-validation": "3.0.1",
+        "@docusaurus/core": "3.1.1",
+        "@docusaurus/logger": "3.1.1",
+        "@docusaurus/plugin-content-docs": "3.1.1",
+        "@docusaurus/theme-common": "3.1.1",
+        "@docusaurus/theme-translations": "3.1.1",
+        "@docusaurus/utils": "3.1.1",
+        "@docusaurus/utils-validation": "3.1.1",
         "algoliasearch": "^4.18.0",
         "algoliasearch-helper": "^3.13.3",
         "clsx": "^2.0.0",
@@ -2668,9 +2668,9 @@
       }
     },
     "node_modules/@docusaurus/theme-translations": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-translations/-/theme-translations-3.0.1.tgz",
-      "integrity": "sha512-6UrbpzCTN6NIJnAtZ6Ne9492vmPVX+7Fsz4kmp+yor3KQwA1+MCzQP7ItDNkP38UmVLnvB/cYk/IvehCUqS3dg==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-translations/-/theme-translations-3.1.1.tgz",
+      "integrity": "sha512-xvWQFwjxHphpJq5fgk37FXCDdAa2o+r7FX8IpMg+bGZBNXyWBu3MjZ+G4+eUVNpDhVinTc+j6ucL0Ain5KCGrg==",
       "dependencies": {
         "fs-extra": "^11.1.1",
         "tslib": "^2.6.0"
@@ -2680,10 +2680,11 @@
       }
     },
     "node_modules/@docusaurus/types": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-3.0.1.tgz",
-      "integrity": "sha512-plyX2iU1tcUsF46uQ01pAd4JhexR7n0iiQ5MSnBFX6M6NSJgDYdru/i1/YNPKOnQHBoXGLHv0dNT6OAlDWNjrg==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-3.1.1.tgz",
+      "integrity": "sha512-grBqOLnubUecgKFXN9q3uit2HFbCxTWX4Fam3ZFbMN0sWX9wOcDoA7lwdX/8AmeL20Oc4kQvWVgNrsT8bKRvzg==",
       "dependencies": {
+        "@mdx-js/mdx": "^3.0.0",
         "@types/history": "^4.7.11",
         "@types/react": "*",
         "commander": "^5.1.0",
@@ -2699,11 +2700,11 @@
       }
     },
     "node_modules/@docusaurus/utils": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils/-/utils-3.0.1.tgz",
-      "integrity": "sha512-TwZ33Am0q4IIbvjhUOs+zpjtD/mXNmLmEgeTGuRq01QzulLHuPhaBTTAC/DHu6kFx3wDgmgpAlaRuCHfTcXv8g==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/utils/-/utils-3.1.1.tgz",
+      "integrity": "sha512-ZJfJa5cJQtRYtqijsPEnAZoduW6sjAQ7ZCWSZavLcV10Fw0Z3gSaPKA/B4micvj2afRZ4gZxT7KfYqe5H8Cetg==",
       "dependencies": {
-        "@docusaurus/logger": "3.0.1",
+        "@docusaurus/logger": "3.1.1",
         "@svgr/webpack": "^6.5.1",
         "escape-string-regexp": "^4.0.0",
         "file-loader": "^6.2.0",
@@ -2734,9 +2735,9 @@
       }
     },
     "node_modules/@docusaurus/utils-common": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils-common/-/utils-common-3.0.1.tgz",
-      "integrity": "sha512-W0AxD6w6T8g6bNro8nBRWf7PeZ/nn7geEWM335qHU2DDDjHuV4UZjgUGP1AQsdcSikPrlIqTJJbKzer1lRSlIg==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/utils-common/-/utils-common-3.1.1.tgz",
+      "integrity": "sha512-eGne3olsIoNfPug5ixjepZAIxeYFzHHnor55Wb2P57jNbtVaFvij/T+MS8U0dtZRFi50QU+UPmRrXdVUM8uyMg==",
       "dependencies": {
         "tslib": "^2.6.0"
       },
@@ -2753,12 +2754,12 @@
       }
     },
     "node_modules/@docusaurus/utils-validation": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils-validation/-/utils-validation-3.0.1.tgz",
-      "integrity": "sha512-ujTnqSfyGQ7/4iZdB4RRuHKY/Nwm58IIb+41s5tCXOv/MBU2wGAjOHq3U+AEyJ8aKQcHbxvTKJaRchNHYUVUQg==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/utils-validation/-/utils-validation-3.1.1.tgz",
+      "integrity": "sha512-KlY4P9YVDnwL+nExvlIpu79abfEv6ZCHuOX4ZQ+gtip+Wxj0daccdReIWWtqxM/Fb5Cz1nQvUCc7VEtT8IBUAA==",
       "dependencies": {
-        "@docusaurus/logger": "3.0.1",
-        "@docusaurus/utils": "3.0.1",
+        "@docusaurus/logger": "3.1.1",
+        "@docusaurus/utils": "3.1.1",
         "joi": "^17.9.2",
         "js-yaml": "^4.1.0",
         "tslib": "^2.6.0"
@@ -2989,9 +2990,9 @@
       "integrity": "sha512-2LuNTFBIO0m7kKIQvvPHN6UE63VjpmL9rnEEaOOaiSPbZK+zUOYIzBAWcED+3XYzhYsd/0mD57VdxAEqqV52CQ=="
     },
     "node_modules/@sideway/address": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@sideway/address/-/address-4.1.4.tgz",
-      "integrity": "sha512-7vwq+rOHVWjyXxVlR76Agnvhy8I9rpzjosTESvmhNeXOXdZZB15Fl+TI9x1SiHZH5Jv2wTGduSxFDIaq0m3DUw==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@sideway/address/-/address-4.1.5.tgz",
+      "integrity": "sha512-IqO/DUQHUkPeixNQ8n0JA6102hT9CmaljNTPmQ1u8MEhBo/R4Q8eKLN/vGZxuebwOroDB4cbpjheD4+/sKFK4Q==",
       "dependencies": {
         "@hapi/hoek": "^9.0.0"
       }
@@ -3934,30 +3935,30 @@
       }
     },
     "node_modules/algoliasearch": {
-      "version": "4.22.0",
-      "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-4.22.0.tgz",
-      "integrity": "sha512-gfceltjkwh7PxXwtkS8KVvdfK+TSNQAWUeNSxf4dA29qW5tf2EGwa8jkJujlT9jLm17cixMVoGNc+GJFO1Mxhg==",
+      "version": "4.22.1",
+      "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-4.22.1.tgz",
+      "integrity": "sha512-jwydKFQJKIx9kIZ8Jm44SdpigFwRGPESaxZBaHSV0XWN2yBJAOT4mT7ppvlrpA4UGzz92pqFnVKr/kaZXrcreg==",
       "dependencies": {
-        "@algolia/cache-browser-local-storage": "4.22.0",
-        "@algolia/cache-common": "4.22.0",
-        "@algolia/cache-in-memory": "4.22.0",
-        "@algolia/client-account": "4.22.0",
-        "@algolia/client-analytics": "4.22.0",
-        "@algolia/client-common": "4.22.0",
-        "@algolia/client-personalization": "4.22.0",
-        "@algolia/client-search": "4.22.0",
-        "@algolia/logger-common": "4.22.0",
-        "@algolia/logger-console": "4.22.0",
-        "@algolia/requester-browser-xhr": "4.22.0",
-        "@algolia/requester-common": "4.22.0",
-        "@algolia/requester-node-http": "4.22.0",
-        "@algolia/transporter": "4.22.0"
+        "@algolia/cache-browser-local-storage": "4.22.1",
+        "@algolia/cache-common": "4.22.1",
+        "@algolia/cache-in-memory": "4.22.1",
+        "@algolia/client-account": "4.22.1",
+        "@algolia/client-analytics": "4.22.1",
+        "@algolia/client-common": "4.22.1",
+        "@algolia/client-personalization": "4.22.1",
+        "@algolia/client-search": "4.22.1",
+        "@algolia/logger-common": "4.22.1",
+        "@algolia/logger-console": "4.22.1",
+        "@algolia/requester-browser-xhr": "4.22.1",
+        "@algolia/requester-common": "4.22.1",
+        "@algolia/requester-node-http": "4.22.1",
+        "@algolia/transporter": "4.22.1"
       }
     },
     "node_modules/algoliasearch-helper": {
-      "version": "3.16.0",
-      "resolved": "https://registry.npmjs.org/algoliasearch-helper/-/algoliasearch-helper-3.16.0.tgz",
-      "integrity": "sha512-RxOtBafSQwyqD5BLO/q9VsVw/zuNz8kjb51OZhCIWLr33uvKB+vrRis+QK+JFlNQXbXf+w28fsTWiBupc1pHew==",
+      "version": "3.16.2",
+      "resolved": "https://registry.npmjs.org/algoliasearch-helper/-/algoliasearch-helper-3.16.2.tgz",
+      "integrity": "sha512-Yl/Gu5Cq4Z5s/AJ0jR37OPI1H3+z7PHz657ibyaXgMOaWvPlZ3OACN13N+7HCLPUlB0BN+8BtmrG/CqTilowBA==",
       "dependencies": {
         "@algolia/events": "^4.0.1"
       },
@@ -6973,9 +6974,9 @@
       }
     },
     "node_modules/hast-util-raw": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/hast-util-raw/-/hast-util-raw-9.0.1.tgz",
-      "integrity": "sha512-5m1gmba658Q+lO5uqL5YNGQWeh1MYWZbZmWrM5lncdcuiXuo5E2HT/CIOp0rLF8ksfSwiCVJ3twlgVRyTGThGA==",
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/hast-util-raw/-/hast-util-raw-9.0.2.tgz",
+      "integrity": "sha512-PldBy71wO9Uq1kyaMch9AHIghtQvIwxBUkv823pKmkTM3oV1JxtsTNYdevMxvUHqcnOAuO65JKU2+0NOxc2ksA==",
       "dependencies": {
         "@types/hast": "^3.0.0",
         "@types/unist": "^3.0.0",
@@ -7444,9 +7445,9 @@
       }
     },
     "node_modules/image-size": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/image-size/-/image-size-1.0.2.tgz",
-      "integrity": "sha512-xfOoWjceHntRb3qFCrh5ZFORYH8XCdYpASltMhZ/Q0KZiOwjdE/Yl2QCiWdwD+lygV5bMCvauzgu5PxBX/Yerg==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/image-size/-/image-size-1.1.1.tgz",
+      "integrity": "sha512-541xKlUw6jr/6gGuk92F+mYM5zaFAc5ahphvkqvNe2bQ6gVBkd6bfrmVJ2t4KDAfikAYZyIqTnktX3i6/aQDrQ==",
       "dependencies": {
         "queue": "6.0.2"
       },
@@ -7454,7 +7455,7 @@
         "image-size": "bin/image-size.js"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.x"
       }
     },
     "node_modules/immer": {
@@ -7895,13 +7896,13 @@
       }
     },
     "node_modules/joi": {
-      "version": "17.11.0",
-      "resolved": "https://registry.npmjs.org/joi/-/joi-17.11.0.tgz",
-      "integrity": "sha512-NgB+lZLNoqISVy1rZocE9PZI36bL/77ie924Ri43yEvi9GUUMPeyVIr8KdFTMUlby1p0PBYMk9spIxEUQYqrJQ==",
+      "version": "17.12.1",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-17.12.1.tgz",
+      "integrity": "sha512-vtxmq+Lsc5SlfqotnfVjlViWfOL9nt/avKNbKYizwf6gsCfq9NYY/ceYRMFD8XDdrjJ9abJyScWmhmIiy+XRtQ==",
       "dependencies": {
-        "@hapi/hoek": "^9.0.0",
-        "@hapi/topo": "^5.0.0",
-        "@sideway/address": "^4.1.3",
+        "@hapi/hoek": "^9.3.0",
+        "@hapi/topo": "^5.1.0",
+        "@sideway/address": "^4.1.5",
         "@sideway/formula": "^3.0.1",
         "@sideway/pinpoint": "^2.0.0"
       }
@@ -8306,9 +8307,9 @@
       }
     },
     "node_modules/mdast-util-gfm-autolink-literal/node_modules/micromark-util-character": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.0.1.tgz",
-      "integrity": "sha512-3wgnrmEAJ4T+mGXAUfMvMAbxU9RDG43XmGce4j6CwPtVxB3vfwXSZ6KhFwDzZ3mZHhmPimMAXg71veiBGzeAZw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.0.tgz",
+      "integrity": "sha512-KvOVV+X1yLBfs9dCBSopq/+G1PcgT3lAK07mC4BzXi5E7ahzMAF8oIupDDJ6mievI6F+lAATkbQQlQixJfT3aQ==",
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -8488,9 +8489,9 @@
       }
     },
     "node_modules/mdast-util-to-hast": {
-      "version": "13.0.2",
-      "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-13.0.2.tgz",
-      "integrity": "sha512-U5I+500EOOw9e3ZrclN3Is3fRpw8c19SMyNZlZ2IS+7vLsNzb2Om11VpIVOR+/0137GhZsFEF6YiKD5+0Hr2Og==",
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-13.1.0.tgz",
+      "integrity": "sha512-/e2l/6+OdGp/FB+ctrJ9Avz71AN/GRH3oi/3KAx/kMnoUsD6q0woXlDT8lLEeViVKE7oZxE7RXzvO3T8kF2/sA==",
       "dependencies": {
         "@types/hast": "^3.0.0",
         "@types/mdast": "^4.0.0",
@@ -8499,7 +8500,8 @@
         "micromark-util-sanitize-uri": "^2.0.0",
         "trim-lines": "^3.0.0",
         "unist-util-position": "^5.0.0",
-        "unist-util-visit": "^5.0.0"
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -8674,9 +8676,9 @@
       }
     },
     "node_modules/micromark-core-commonmark/node_modules/micromark-util-character": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.0.1.tgz",
-      "integrity": "sha512-3wgnrmEAJ4T+mGXAUfMvMAbxU9RDG43XmGce4j6CwPtVxB3vfwXSZ6KhFwDzZ3mZHhmPimMAXg71veiBGzeAZw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.0.tgz",
+      "integrity": "sha512-KvOVV+X1yLBfs9dCBSopq/+G1PcgT3lAK07mC4BzXi5E7ahzMAF8oIupDDJ6mievI6F+lAATkbQQlQixJfT3aQ==",
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -8745,9 +8747,9 @@
       }
     },
     "node_modules/micromark-extension-directive/node_modules/micromark-util-character": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.0.1.tgz",
-      "integrity": "sha512-3wgnrmEAJ4T+mGXAUfMvMAbxU9RDG43XmGce4j6CwPtVxB3vfwXSZ6KhFwDzZ3mZHhmPimMAXg71veiBGzeAZw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.0.tgz",
+      "integrity": "sha512-KvOVV+X1yLBfs9dCBSopq/+G1PcgT3lAK07mC4BzXi5E7ahzMAF8oIupDDJ6mievI6F+lAATkbQQlQixJfT3aQ==",
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -8794,9 +8796,9 @@
       }
     },
     "node_modules/micromark-extension-frontmatter/node_modules/micromark-util-character": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.0.1.tgz",
-      "integrity": "sha512-3wgnrmEAJ4T+mGXAUfMvMAbxU9RDG43XmGce4j6CwPtVxB3vfwXSZ6KhFwDzZ3mZHhmPimMAXg71veiBGzeAZw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.0.tgz",
+      "integrity": "sha512-KvOVV+X1yLBfs9dCBSopq/+G1PcgT3lAK07mC4BzXi5E7ahzMAF8oIupDDJ6mievI6F+lAATkbQQlQixJfT3aQ==",
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -8862,9 +8864,9 @@
       }
     },
     "node_modules/micromark-extension-gfm-autolink-literal/node_modules/micromark-util-character": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.0.1.tgz",
-      "integrity": "sha512-3wgnrmEAJ4T+mGXAUfMvMAbxU9RDG43XmGce4j6CwPtVxB3vfwXSZ6KhFwDzZ3mZHhmPimMAXg71veiBGzeAZw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.0.tgz",
+      "integrity": "sha512-KvOVV+X1yLBfs9dCBSopq/+G1PcgT3lAK07mC4BzXi5E7ahzMAF8oIupDDJ6mievI6F+lAATkbQQlQixJfT3aQ==",
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -8934,9 +8936,9 @@
       }
     },
     "node_modules/micromark-extension-gfm-footnote/node_modules/micromark-util-character": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.0.1.tgz",
-      "integrity": "sha512-3wgnrmEAJ4T+mGXAUfMvMAbxU9RDG43XmGce4j6CwPtVxB3vfwXSZ6KhFwDzZ3mZHhmPimMAXg71veiBGzeAZw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.0.tgz",
+      "integrity": "sha512-KvOVV+X1yLBfs9dCBSopq/+G1PcgT3lAK07mC4BzXi5E7ahzMAF8oIupDDJ6mievI6F+lAATkbQQlQixJfT3aQ==",
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -9035,9 +9037,9 @@
       }
     },
     "node_modules/micromark-extension-gfm-table/node_modules/micromark-util-character": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.0.1.tgz",
-      "integrity": "sha512-3wgnrmEAJ4T+mGXAUfMvMAbxU9RDG43XmGce4j6CwPtVxB3vfwXSZ6KhFwDzZ3mZHhmPimMAXg71veiBGzeAZw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.0.tgz",
+      "integrity": "sha512-KvOVV+X1yLBfs9dCBSopq/+G1PcgT3lAK07mC4BzXi5E7ahzMAF8oIupDDJ6mievI6F+lAATkbQQlQixJfT3aQ==",
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -9116,9 +9118,9 @@
       }
     },
     "node_modules/micromark-extension-gfm-task-list-item/node_modules/micromark-util-character": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.0.1.tgz",
-      "integrity": "sha512-3wgnrmEAJ4T+mGXAUfMvMAbxU9RDG43XmGce4j6CwPtVxB3vfwXSZ6KhFwDzZ3mZHhmPimMAXg71veiBGzeAZw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.0.tgz",
+      "integrity": "sha512-KvOVV+X1yLBfs9dCBSopq/+G1PcgT3lAK07mC4BzXi5E7ahzMAF8oIupDDJ6mievI6F+lAATkbQQlQixJfT3aQ==",
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -9194,9 +9196,9 @@
       }
     },
     "node_modules/micromark-extension-mdx-expression/node_modules/micromark-util-character": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.0.1.tgz",
-      "integrity": "sha512-3wgnrmEAJ4T+mGXAUfMvMAbxU9RDG43XmGce4j6CwPtVxB3vfwXSZ6KhFwDzZ3mZHhmPimMAXg71veiBGzeAZw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.0.tgz",
+      "integrity": "sha512-KvOVV+X1yLBfs9dCBSopq/+G1PcgT3lAK07mC4BzXi5E7ahzMAF8oIupDDJ6mievI6F+lAATkbQQlQixJfT3aQ==",
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -9268,9 +9270,9 @@
       }
     },
     "node_modules/micromark-extension-mdx-jsx/node_modules/micromark-util-character": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.0.1.tgz",
-      "integrity": "sha512-3wgnrmEAJ4T+mGXAUfMvMAbxU9RDG43XmGce4j6CwPtVxB3vfwXSZ6KhFwDzZ3mZHhmPimMAXg71veiBGzeAZw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.0.tgz",
+      "integrity": "sha512-KvOVV+X1yLBfs9dCBSopq/+G1PcgT3lAK07mC4BzXi5E7ahzMAF8oIupDDJ6mievI6F+lAATkbQQlQixJfT3aQ==",
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -9353,9 +9355,9 @@
       }
     },
     "node_modules/micromark-extension-mdxjs-esm/node_modules/micromark-util-character": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.0.1.tgz",
-      "integrity": "sha512-3wgnrmEAJ4T+mGXAUfMvMAbxU9RDG43XmGce4j6CwPtVxB3vfwXSZ6KhFwDzZ3mZHhmPimMAXg71veiBGzeAZw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.0.tgz",
+      "integrity": "sha512-KvOVV+X1yLBfs9dCBSopq/+G1PcgT3lAK07mC4BzXi5E7ahzMAF8oIupDDJ6mievI6F+lAATkbQQlQixJfT3aQ==",
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -9407,9 +9409,9 @@
       }
     },
     "node_modules/micromark-factory-destination/node_modules/micromark-util-character": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.0.1.tgz",
-      "integrity": "sha512-3wgnrmEAJ4T+mGXAUfMvMAbxU9RDG43XmGce4j6CwPtVxB3vfwXSZ6KhFwDzZ3mZHhmPimMAXg71veiBGzeAZw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.0.tgz",
+      "integrity": "sha512-KvOVV+X1yLBfs9dCBSopq/+G1PcgT3lAK07mC4BzXi5E7ahzMAF8oIupDDJ6mievI6F+lAATkbQQlQixJfT3aQ==",
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -9462,9 +9464,9 @@
       }
     },
     "node_modules/micromark-factory-label/node_modules/micromark-util-character": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.0.1.tgz",
-      "integrity": "sha512-3wgnrmEAJ4T+mGXAUfMvMAbxU9RDG43XmGce4j6CwPtVxB3vfwXSZ6KhFwDzZ3mZHhmPimMAXg71veiBGzeAZw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.0.tgz",
+      "integrity": "sha512-KvOVV+X1yLBfs9dCBSopq/+G1PcgT3lAK07mC4BzXi5E7ahzMAF8oIupDDJ6mievI6F+lAATkbQQlQixJfT3aQ==",
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -9521,9 +9523,9 @@
       }
     },
     "node_modules/micromark-factory-mdx-expression/node_modules/micromark-util-character": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.0.1.tgz",
-      "integrity": "sha512-3wgnrmEAJ4T+mGXAUfMvMAbxU9RDG43XmGce4j6CwPtVxB3vfwXSZ6KhFwDzZ3mZHhmPimMAXg71veiBGzeAZw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.0.tgz",
+      "integrity": "sha512-KvOVV+X1yLBfs9dCBSopq/+G1PcgT3lAK07mC4BzXi5E7ahzMAF8oIupDDJ6mievI6F+lAATkbQQlQixJfT3aQ==",
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -9629,9 +9631,9 @@
       }
     },
     "node_modules/micromark-factory-title/node_modules/micromark-util-character": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.0.1.tgz",
-      "integrity": "sha512-3wgnrmEAJ4T+mGXAUfMvMAbxU9RDG43XmGce4j6CwPtVxB3vfwXSZ6KhFwDzZ3mZHhmPimMAXg71veiBGzeAZw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.0.tgz",
+      "integrity": "sha512-KvOVV+X1yLBfs9dCBSopq/+G1PcgT3lAK07mC4BzXi5E7ahzMAF8oIupDDJ6mievI6F+lAATkbQQlQixJfT3aQ==",
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -9703,9 +9705,9 @@
       }
     },
     "node_modules/micromark-factory-whitespace/node_modules/micromark-util-character": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.0.1.tgz",
-      "integrity": "sha512-3wgnrmEAJ4T+mGXAUfMvMAbxU9RDG43XmGce4j6CwPtVxB3vfwXSZ6KhFwDzZ3mZHhmPimMAXg71veiBGzeAZw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.0.tgz",
+      "integrity": "sha512-KvOVV+X1yLBfs9dCBSopq/+G1PcgT3lAK07mC4BzXi5E7ahzMAF8oIupDDJ6mievI6F+lAATkbQQlQixJfT3aQ==",
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -9824,9 +9826,9 @@
       }
     },
     "node_modules/micromark-util-classify-character/node_modules/micromark-util-character": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.0.1.tgz",
-      "integrity": "sha512-3wgnrmEAJ4T+mGXAUfMvMAbxU9RDG43XmGce4j6CwPtVxB3vfwXSZ6KhFwDzZ3mZHhmPimMAXg71veiBGzeAZw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.0.tgz",
+      "integrity": "sha512-KvOVV+X1yLBfs9dCBSopq/+G1PcgT3lAK07mC4BzXi5E7ahzMAF8oIupDDJ6mievI6F+lAATkbQQlQixJfT3aQ==",
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -9931,9 +9933,9 @@
       }
     },
     "node_modules/micromark-util-decode-string/node_modules/micromark-util-character": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.0.1.tgz",
-      "integrity": "sha512-3wgnrmEAJ4T+mGXAUfMvMAbxU9RDG43XmGce4j6CwPtVxB3vfwXSZ6KhFwDzZ3mZHhmPimMAXg71veiBGzeAZw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.0.tgz",
+      "integrity": "sha512-KvOVV+X1yLBfs9dCBSopq/+G1PcgT3lAK07mC4BzXi5E7ahzMAF8oIupDDJ6mievI6F+lAATkbQQlQixJfT3aQ==",
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -10106,9 +10108,9 @@
       }
     },
     "node_modules/micromark-util-sanitize-uri/node_modules/micromark-util-character": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.0.1.tgz",
-      "integrity": "sha512-3wgnrmEAJ4T+mGXAUfMvMAbxU9RDG43XmGce4j6CwPtVxB3vfwXSZ6KhFwDzZ3mZHhmPimMAXg71veiBGzeAZw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.0.tgz",
+      "integrity": "sha512-KvOVV+X1yLBfs9dCBSopq/+G1PcgT3lAK07mC4BzXi5E7ahzMAF8oIupDDJ6mievI6F+lAATkbQQlQixJfT3aQ==",
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -10225,9 +10227,9 @@
       }
     },
     "node_modules/micromark/node_modules/micromark-util-character": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.0.1.tgz",
-      "integrity": "sha512-3wgnrmEAJ4T+mGXAUfMvMAbxU9RDG43XmGce4j6CwPtVxB3vfwXSZ6KhFwDzZ3mZHhmPimMAXg71veiBGzeAZw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.0.tgz",
+      "integrity": "sha512-KvOVV+X1yLBfs9dCBSopq/+G1PcgT3lAK07mC4BzXi5E7ahzMAF8oIupDDJ6mievI6F+lAATkbQQlQixJfT3aQ==",
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -11675,9 +11677,9 @@
       }
     },
     "node_modules/property-information": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/property-information/-/property-information-6.4.0.tgz",
-      "integrity": "sha512-9t5qARVofg2xQqKtytzt+lZ4d1Qvj8t5B8fEwXK6qOfgRLgH/b13QlgEyDh033NOS31nXeFbYv7CLUDG1CeifQ==",
+      "version": "6.4.1",
+      "resolved": "https://registry.npmjs.org/property-information/-/property-information-6.4.1.tgz",
+      "integrity": "sha512-OHYtXfu5aI2sS2LWFSN5rgJjrQ4pCy8i1jubJLe2QvMF8JJ++HXTUIVWFLfXJoaOfvYYjk2SN8J2wFUWIGXT4w==",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
@@ -12351,9 +12353,9 @@
       }
     },
     "node_modules/remark-rehype": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/remark-rehype/-/remark-rehype-11.0.0.tgz",
-      "integrity": "sha512-vx8x2MDMcxuE4lBmQ46zYUDfcFMmvg80WYX+UNLeG6ixjdCCLcw1lrgAukwBTuOFsS78eoAedHGn9sNM0w7TPw==",
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/remark-rehype/-/remark-rehype-11.1.0.tgz",
+      "integrity": "sha512-z3tJrAs2kIs1AqIIy6pzHmAHlF1hWQ+OdY4/hv+Wxe35EhyLKcajL33iUEn3ScxtFox9nUvRufR/Zre8Q08H/g==",
       "dependencies": {
         "@types/hast": "^3.0.0",
         "@types/mdast": "^4.0.0",
@@ -14144,9 +14146,9 @@
       "integrity": "sha512-Z0DbgELS9/L/75wZbro8xAnT50pBVFQZ+hUEueGDU5FN51YSCYM+jdxsfCiHjwNP/4LCDD0i/graKpeBnOXKRA=="
     },
     "node_modules/utility-types": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/utility-types/-/utility-types-3.10.0.tgz",
-      "integrity": "sha512-O11mqxmi7wMKCo6HKFt5AhO4BwY3VV68YU07tgxfz8zJTIxr4BpsezN49Ffwy9j3ZpwwJp4fkRwjRzq3uWE6Rg==",
+      "version": "3.11.0",
+      "resolved": "https://registry.npmjs.org/utility-types/-/utility-types-3.11.0.tgz",
+      "integrity": "sha512-6Z7Ma2aVEWisaL6TvBCy7P8rm2LQoPv6dJ7ecIaIixHcwfbJ0x7mWdbcwlIM5IGQxPZSFYeqRCqlOOeKoJYMkw==",
       "engines": {
         "node": ">= 4"
       }
@@ -14812,74 +14814,74 @@
       "requires": {}
     },
     "@algolia/cache-browser-local-storage": {
-      "version": "4.22.0",
-      "resolved": "https://registry.npmjs.org/@algolia/cache-browser-local-storage/-/cache-browser-local-storage-4.22.0.tgz",
-      "integrity": "sha512-uZ1uZMLDZb4qODLfTSNHxSi4fH9RdrQf7DXEzW01dS8XK7QFtFh29N5NGKa9S+Yudf1vUMIF+/RiL4i/J0pWlQ==",
+      "version": "4.22.1",
+      "resolved": "https://registry.npmjs.org/@algolia/cache-browser-local-storage/-/cache-browser-local-storage-4.22.1.tgz",
+      "integrity": "sha512-Sw6IAmOCvvP6QNgY9j+Hv09mvkvEIDKjYW8ow0UDDAxSXy664RBNQk3i/0nt7gvceOJ6jGmOTimaZoY1THmU7g==",
       "requires": {
-        "@algolia/cache-common": "4.22.0"
+        "@algolia/cache-common": "4.22.1"
       }
     },
     "@algolia/cache-common": {
-      "version": "4.22.0",
-      "resolved": "https://registry.npmjs.org/@algolia/cache-common/-/cache-common-4.22.0.tgz",
-      "integrity": "sha512-TPwUMlIGPN16eW67qamNQUmxNiGHg/WBqWcrOoCddhqNTqGDPVqmgfaM85LPbt24t3r1z0zEz/tdsmuq3Q6oaA=="
+      "version": "4.22.1",
+      "resolved": "https://registry.npmjs.org/@algolia/cache-common/-/cache-common-4.22.1.tgz",
+      "integrity": "sha512-TJMBKqZNKYB9TptRRjSUtevJeQVXRmg6rk9qgFKWvOy8jhCPdyNZV1nB3SKGufzvTVbomAukFR8guu/8NRKBTA=="
     },
     "@algolia/cache-in-memory": {
-      "version": "4.22.0",
-      "resolved": "https://registry.npmjs.org/@algolia/cache-in-memory/-/cache-in-memory-4.22.0.tgz",
-      "integrity": "sha512-kf4Cio9NpPjzp1+uXQgL4jsMDeck7MP89BYThSvXSjf2A6qV/0KeqQf90TL2ECS02ovLOBXkk98P7qVarM+zGA==",
+      "version": "4.22.1",
+      "resolved": "https://registry.npmjs.org/@algolia/cache-in-memory/-/cache-in-memory-4.22.1.tgz",
+      "integrity": "sha512-ve+6Ac2LhwpufuWavM/aHjLoNz/Z/sYSgNIXsinGofWOysPilQZPUetqLj8vbvi+DHZZaYSEP9H5SRVXnpsNNw==",
       "requires": {
-        "@algolia/cache-common": "4.22.0"
+        "@algolia/cache-common": "4.22.1"
       }
     },
     "@algolia/client-account": {
-      "version": "4.22.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-account/-/client-account-4.22.0.tgz",
-      "integrity": "sha512-Bjb5UXpWmJT+yGWiqAJL0prkENyEZTBzdC+N1vBuHjwIJcjLMjPB6j1hNBRbT12Lmwi55uzqeMIKS69w+0aPzA==",
+      "version": "4.22.1",
+      "resolved": "https://registry.npmjs.org/@algolia/client-account/-/client-account-4.22.1.tgz",
+      "integrity": "sha512-k8m+oegM2zlns/TwZyi4YgCtyToackkOpE+xCaKCYfBfDtdGOaVZCM5YvGPtK+HGaJMIN/DoTL8asbM3NzHonw==",
       "requires": {
-        "@algolia/client-common": "4.22.0",
-        "@algolia/client-search": "4.22.0",
-        "@algolia/transporter": "4.22.0"
+        "@algolia/client-common": "4.22.1",
+        "@algolia/client-search": "4.22.1",
+        "@algolia/transporter": "4.22.1"
       }
     },
     "@algolia/client-analytics": {
-      "version": "4.22.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-4.22.0.tgz",
-      "integrity": "sha512-os2K+kHUcwwRa4ArFl5p/3YbF9lN3TLOPkbXXXxOvDpqFh62n9IRZuzfxpHxMPKAQS3Et1s0BkKavnNP02E9Hg==",
+      "version": "4.22.1",
+      "resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-4.22.1.tgz",
+      "integrity": "sha512-1ssi9pyxyQNN4a7Ji9R50nSdISIumMFDwKNuwZipB6TkauJ8J7ha/uO60sPJFqQyqvvI+px7RSNRQT3Zrvzieg==",
       "requires": {
-        "@algolia/client-common": "4.22.0",
-        "@algolia/client-search": "4.22.0",
-        "@algolia/requester-common": "4.22.0",
-        "@algolia/transporter": "4.22.0"
+        "@algolia/client-common": "4.22.1",
+        "@algolia/client-search": "4.22.1",
+        "@algolia/requester-common": "4.22.1",
+        "@algolia/transporter": "4.22.1"
       }
     },
     "@algolia/client-common": {
-      "version": "4.22.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-4.22.0.tgz",
-      "integrity": "sha512-BlbkF4qXVWuwTmYxVWvqtatCR3lzXwxx628p1wj1Q7QP2+LsTmGt1DiUYRuy9jG7iMsnlExby6kRMOOlbhv2Ag==",
+      "version": "4.22.1",
+      "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-4.22.1.tgz",
+      "integrity": "sha512-IvaL5v9mZtm4k4QHbBGDmU3wa/mKokmqNBqPj0K7lcR8ZDKzUorhcGp/u8PkPC/e0zoHSTvRh7TRkGX3Lm7iOQ==",
       "requires": {
-        "@algolia/requester-common": "4.22.0",
-        "@algolia/transporter": "4.22.0"
+        "@algolia/requester-common": "4.22.1",
+        "@algolia/transporter": "4.22.1"
       }
     },
     "@algolia/client-personalization": {
-      "version": "4.22.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-personalization/-/client-personalization-4.22.0.tgz",
-      "integrity": "sha512-pEOftCxeBdG5pL97WngOBi9w5Vxr5KCV2j2D+xMVZH8MuU/JX7CglDSDDb0ffQWYqcUN+40Ry+xtXEYaGXTGow==",
+      "version": "4.22.1",
+      "resolved": "https://registry.npmjs.org/@algolia/client-personalization/-/client-personalization-4.22.1.tgz",
+      "integrity": "sha512-sl+/klQJ93+4yaqZ7ezOttMQ/nczly/3GmgZXJ1xmoewP5jmdP/X/nV5U7EHHH3hCUEHeN7X1nsIhGPVt9E1cQ==",
       "requires": {
-        "@algolia/client-common": "4.22.0",
-        "@algolia/requester-common": "4.22.0",
-        "@algolia/transporter": "4.22.0"
+        "@algolia/client-common": "4.22.1",
+        "@algolia/requester-common": "4.22.1",
+        "@algolia/transporter": "4.22.1"
       }
     },
     "@algolia/client-search": {
-      "version": "4.22.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-4.22.0.tgz",
-      "integrity": "sha512-bn4qQiIdRPBGCwsNuuqB8rdHhGKKWIij9OqidM1UkQxnSG8yzxHdb7CujM30pvp5EnV7jTqDZRbxacbjYVW20Q==",
+      "version": "4.22.1",
+      "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-4.22.1.tgz",
+      "integrity": "sha512-yb05NA4tNaOgx3+rOxAmFztgMTtGBi97X7PC3jyNeGiwkAjOZc2QrdZBYyIdcDLoI09N0gjtpClcackoTN0gPA==",
       "requires": {
-        "@algolia/client-common": "4.22.0",
-        "@algolia/requester-common": "4.22.0",
-        "@algolia/transporter": "4.22.0"
+        "@algolia/client-common": "4.22.1",
+        "@algolia/requester-common": "4.22.1",
+        "@algolia/transporter": "4.22.1"
       }
     },
     "@algolia/events": {
@@ -14888,47 +14890,47 @@
       "integrity": "sha512-FQzvOCgoFXAbf5Y6mYozw2aj5KCJoA3m4heImceldzPSMbdyS4atVjJzXKMsfX3wnZTFYwkkt8/z8UesLHlSBQ=="
     },
     "@algolia/logger-common": {
-      "version": "4.22.0",
-      "resolved": "https://registry.npmjs.org/@algolia/logger-common/-/logger-common-4.22.0.tgz",
-      "integrity": "sha512-HMUQTID0ucxNCXs5d1eBJ5q/HuKg8rFVE/vOiLaM4Abfeq1YnTtGV3+rFEhOPWhRQxNDd+YHa4q864IMc0zHpQ=="
+      "version": "4.22.1",
+      "resolved": "https://registry.npmjs.org/@algolia/logger-common/-/logger-common-4.22.1.tgz",
+      "integrity": "sha512-OnTFymd2odHSO39r4DSWRFETkBufnY2iGUZNrMXpIhF5cmFE8pGoINNPzwg02QLBlGSaLqdKy0bM8S0GyqPLBg=="
     },
     "@algolia/logger-console": {
-      "version": "4.22.0",
-      "resolved": "https://registry.npmjs.org/@algolia/logger-console/-/logger-console-4.22.0.tgz",
-      "integrity": "sha512-7JKb6hgcY64H7CRm3u6DRAiiEVXMvCJV5gRE672QFOUgDxo4aiDpfU61g6Uzy8NKjlEzHMmgG4e2fklELmPXhQ==",
+      "version": "4.22.1",
+      "resolved": "https://registry.npmjs.org/@algolia/logger-console/-/logger-console-4.22.1.tgz",
+      "integrity": "sha512-O99rcqpVPKN1RlpgD6H3khUWylU24OXlzkavUAMy6QZd1776QAcauE3oP8CmD43nbaTjBexZj2nGsBH9Tc0FVA==",
       "requires": {
-        "@algolia/logger-common": "4.22.0"
+        "@algolia/logger-common": "4.22.1"
       }
     },
     "@algolia/requester-browser-xhr": {
-      "version": "4.22.0",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-4.22.0.tgz",
-      "integrity": "sha512-BHfv1h7P9/SyvcDJDaRuIwDu2yrDLlXlYmjvaLZTtPw6Ok/ZVhBR55JqW832XN/Fsl6k3LjdkYHHR7xnsa5Wvg==",
+      "version": "4.22.1",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-4.22.1.tgz",
+      "integrity": "sha512-dtQGYIg6MteqT1Uay3J/0NDqD+UciHy3QgRbk7bNddOJu+p3hzjTRYESqEnoX/DpEkaNYdRHUKNylsqMpgwaEw==",
       "requires": {
-        "@algolia/requester-common": "4.22.0"
+        "@algolia/requester-common": "4.22.1"
       }
     },
     "@algolia/requester-common": {
-      "version": "4.22.0",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-common/-/requester-common-4.22.0.tgz",
-      "integrity": "sha512-Y9cEH/cKjIIZgzvI1aI0ARdtR/xRrOR13g5psCxkdhpgRN0Vcorx+zePhmAa4jdQNqexpxtkUdcKYugBzMZJgQ=="
+      "version": "4.22.1",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-common/-/requester-common-4.22.1.tgz",
+      "integrity": "sha512-dgvhSAtg2MJnR+BxrIFqlLtkLlVVhas9HgYKMk2Uxiy5m6/8HZBL40JVAMb2LovoPFs9I/EWIoFVjOrFwzn5Qg=="
     },
     "@algolia/requester-node-http": {
-      "version": "4.22.0",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-4.22.0.tgz",
-      "integrity": "sha512-8xHoGpxVhz3u2MYIieHIB6MsnX+vfd5PS4REgglejJ6lPigftRhTdBCToe6zbwq4p0anZXjjPDvNWMlgK2+xYA==",
+      "version": "4.22.1",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-4.22.1.tgz",
+      "integrity": "sha512-JfmZ3MVFQkAU+zug8H3s8rZ6h0ahHZL/SpMaSasTCGYR5EEJsCc8SI5UZ6raPN2tjxa5bxS13BRpGSBUens7EA==",
       "requires": {
-        "@algolia/requester-common": "4.22.0"
+        "@algolia/requester-common": "4.22.1"
       }
     },
     "@algolia/transporter": {
-      "version": "4.22.0",
-      "resolved": "https://registry.npmjs.org/@algolia/transporter/-/transporter-4.22.0.tgz",
-      "integrity": "sha512-ieO1k8x2o77GNvOoC+vAkFKppydQSVfbjM3YrSjLmgywiBejPTvU1R1nEvG59JIIUvtSLrZsLGPkd6vL14zopA==",
+      "version": "4.22.1",
+      "resolved": "https://registry.npmjs.org/@algolia/transporter/-/transporter-4.22.1.tgz",
+      "integrity": "sha512-kzWgc2c9IdxMa3YqA6TN0NW5VrKYYW/BELIn7vnLyn+U/RFdZ4lxxt9/8yq3DKV5snvoDzzO4ClyejZRdV3lMQ==",
       "requires": {
-        "@algolia/cache-common": "4.22.0",
-        "@algolia/logger-common": "4.22.0",
-        "@algolia/requester-common": "4.22.0"
+        "@algolia/cache-common": "4.22.1",
+        "@algolia/logger-common": "4.22.1",
+        "@algolia/requester-common": "4.22.1"
       }
     },
     "@ampproject/remapping": {
@@ -16275,9 +16277,9 @@
       }
     },
     "@docusaurus/core": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-3.0.1.tgz",
-      "integrity": "sha512-CXrLpOnW+dJdSv8M5FAJ3JBwXtL6mhUWxFA8aS0ozK6jBG/wgxERk5uvH28fCeFxOGbAT9v1e9dOMo1X2IEVhQ==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-3.1.1.tgz",
+      "integrity": "sha512-2nQfKFcf+MLEM7JXsXwQxPOmQAR6ytKMZVSx7tVi9HEm9WtfwBH1fp6bn8Gj4zLUhjWKCLoysQ9/Wm+EZCQ4yQ==",
       "requires": {
         "@babel/core": "^7.23.3",
         "@babel/generator": "^7.23.3",
@@ -16289,13 +16291,13 @@
         "@babel/runtime": "^7.22.6",
         "@babel/runtime-corejs3": "^7.22.6",
         "@babel/traverse": "^7.22.8",
-        "@docusaurus/cssnano-preset": "3.0.1",
-        "@docusaurus/logger": "3.0.1",
-        "@docusaurus/mdx-loader": "3.0.1",
+        "@docusaurus/cssnano-preset": "3.1.1",
+        "@docusaurus/logger": "3.1.1",
+        "@docusaurus/mdx-loader": "3.1.1",
         "@docusaurus/react-loadable": "5.5.2",
-        "@docusaurus/utils": "3.0.1",
-        "@docusaurus/utils-common": "3.0.1",
-        "@docusaurus/utils-validation": "3.0.1",
+        "@docusaurus/utils": "3.1.1",
+        "@docusaurus/utils-common": "3.1.1",
+        "@docusaurus/utils-validation": "3.1.1",
         "@slorber/static-site-generator-webpack-plugin": "^4.0.7",
         "@svgr/webpack": "^6.5.1",
         "autoprefixer": "^10.4.14",
@@ -16351,9 +16353,9 @@
       }
     },
     "@docusaurus/cssnano-preset": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/cssnano-preset/-/cssnano-preset-3.0.1.tgz",
-      "integrity": "sha512-wjuXzkHMW+ig4BD6Ya1Yevx9UJadO4smNZCEljqBoQfIQrQskTswBs7lZ8InHP7mCt273a/y/rm36EZhqJhknQ==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/cssnano-preset/-/cssnano-preset-3.1.1.tgz",
+      "integrity": "sha512-LnoIDjJWbirdbVZDMq+4hwmrTl2yHDnBf9MLG9qyExeAE3ac35s4yUhJI8yyTCdixzNfKit4cbXblzzqMu4+8g==",
       "requires": {
         "cssnano-preset-advanced": "^5.3.10",
         "postcss": "^8.4.26",
@@ -16362,24 +16364,24 @@
       }
     },
     "@docusaurus/logger": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/logger/-/logger-3.0.1.tgz",
-      "integrity": "sha512-I5L6Nk8OJzkVA91O2uftmo71LBSxe1vmOn9AMR6JRCzYeEBrqneWMH02AqMvjJ2NpMiviO+t0CyPjyYV7nxCWQ==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/logger/-/logger-3.1.1.tgz",
+      "integrity": "sha512-BjkNDpQzewcTnST8trx4idSoAla6zZ3w22NqM/UMcFtvYJgmoE4layuTzlfql3VFPNuivvj7BOExa/+21y4X2Q==",
       "requires": {
         "chalk": "^4.1.2",
         "tslib": "^2.6.0"
       }
     },
     "@docusaurus/mdx-loader": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/mdx-loader/-/mdx-loader-3.0.1.tgz",
-      "integrity": "sha512-ldnTmvnvlrONUq45oKESrpy+lXtbnTcTsFkOTIDswe5xx5iWJjt6eSa0f99ZaWlnm24mlojcIGoUWNCS53qVlQ==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/mdx-loader/-/mdx-loader-3.1.1.tgz",
+      "integrity": "sha512-xN2IccH9+sv7TmxwsDJNS97BHdmlqWwho+kIVY4tcCXkp+k4QuzvWBeunIMzeayY4Fu13A6sAjHGv5qm72KyGA==",
       "requires": {
         "@babel/parser": "^7.22.7",
         "@babel/traverse": "^7.22.8",
-        "@docusaurus/logger": "3.0.1",
-        "@docusaurus/utils": "3.0.1",
-        "@docusaurus/utils-validation": "3.0.1",
+        "@docusaurus/logger": "3.1.1",
+        "@docusaurus/utils": "3.1.1",
+        "@docusaurus/utils-validation": "3.1.1",
         "@mdx-js/mdx": "^3.0.0",
         "@slorber/remark-comment": "^1.0.0",
         "escape-html": "^1.0.3",
@@ -16404,12 +16406,12 @@
       }
     },
     "@docusaurus/module-type-aliases": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/module-type-aliases/-/module-type-aliases-3.0.1.tgz",
-      "integrity": "sha512-DEHpeqUDsLynl3AhQQiO7AbC7/z/lBra34jTcdYuvp9eGm01pfH1wTVq8YqWZq6Jyx0BgcVl/VJqtE9StRd9Ag==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/module-type-aliases/-/module-type-aliases-3.1.1.tgz",
+      "integrity": "sha512-xBJyx0TMfAfVZ9ZeIOb1awdXgR4YJMocIEzTps91rq+hJDFJgJaylDtmoRhUxkwuYmNK1GJpW95b7DLztSBJ3A==",
       "requires": {
         "@docusaurus/react-loadable": "5.5.2",
-        "@docusaurus/types": "3.0.1",
+        "@docusaurus/types": "3.1.1",
         "@types/history": "^4.7.11",
         "@types/react": "*",
         "@types/react-router-config": "*",
@@ -16419,17 +16421,17 @@
       }
     },
     "@docusaurus/plugin-content-blog": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-blog/-/plugin-content-blog-3.0.1.tgz",
-      "integrity": "sha512-cLOvtvAyaMQFLI8vm4j26svg3ktxMPSXpuUJ7EERKoGbfpJSsgtowNHcRsaBVmfuCsRSk1HZ/yHBsUkTmHFEsg==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-blog/-/plugin-content-blog-3.1.1.tgz",
+      "integrity": "sha512-ew/3VtVoG3emoAKmoZl7oKe1zdFOsI0NbcHS26kIxt2Z8vcXKCUgK9jJJrz0TbOipyETPhqwq4nbitrY3baibg==",
       "requires": {
-        "@docusaurus/core": "3.0.1",
-        "@docusaurus/logger": "3.0.1",
-        "@docusaurus/mdx-loader": "3.0.1",
-        "@docusaurus/types": "3.0.1",
-        "@docusaurus/utils": "3.0.1",
-        "@docusaurus/utils-common": "3.0.1",
-        "@docusaurus/utils-validation": "3.0.1",
+        "@docusaurus/core": "3.1.1",
+        "@docusaurus/logger": "3.1.1",
+        "@docusaurus/mdx-loader": "3.1.1",
+        "@docusaurus/types": "3.1.1",
+        "@docusaurus/utils": "3.1.1",
+        "@docusaurus/utils-common": "3.1.1",
+        "@docusaurus/utils-validation": "3.1.1",
         "cheerio": "^1.0.0-rc.12",
         "feed": "^4.2.2",
         "fs-extra": "^11.1.1",
@@ -16443,17 +16445,17 @@
       }
     },
     "@docusaurus/plugin-content-docs": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-docs/-/plugin-content-docs-3.0.1.tgz",
-      "integrity": "sha512-dRfAOA5Ivo+sdzzJGXEu33yAtvGg8dlZkvt/NEJ7nwi1F2j4LEdsxtfX2GKeETB2fP6XoGNSQnFXqa2NYGrHFg==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-docs/-/plugin-content-docs-3.1.1.tgz",
+      "integrity": "sha512-lhFq4E874zw0UOH7ujzxnCayOyAt0f9YPVYSb9ohxrdCM8B4szxitUw9rIX4V9JLLHVoqIJb6k+lJJ1jrcGJ0A==",
       "requires": {
-        "@docusaurus/core": "3.0.1",
-        "@docusaurus/logger": "3.0.1",
-        "@docusaurus/mdx-loader": "3.0.1",
-        "@docusaurus/module-type-aliases": "3.0.1",
-        "@docusaurus/types": "3.0.1",
-        "@docusaurus/utils": "3.0.1",
-        "@docusaurus/utils-validation": "3.0.1",
+        "@docusaurus/core": "3.1.1",
+        "@docusaurus/logger": "3.1.1",
+        "@docusaurus/mdx-loader": "3.1.1",
+        "@docusaurus/module-type-aliases": "3.1.1",
+        "@docusaurus/types": "3.1.1",
+        "@docusaurus/utils": "3.1.1",
+        "@docusaurus/utils-validation": "3.1.1",
         "@types/react-router-config": "^5.0.7",
         "combine-promises": "^1.1.0",
         "fs-extra": "^11.1.1",
@@ -16465,101 +16467,101 @@
       }
     },
     "@docusaurus/plugin-content-pages": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-pages/-/plugin-content-pages-3.0.1.tgz",
-      "integrity": "sha512-oP7PoYizKAXyEttcvVzfX3OoBIXEmXTMzCdfmC4oSwjG4SPcJsRge3mmI6O8jcZBgUPjIzXD21bVGWEE1iu8gg==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-pages/-/plugin-content-pages-3.1.1.tgz",
+      "integrity": "sha512-NQHncNRAJbyLtgTim9GlEnNYsFhuCxaCNkMwikuxLTiGIPH7r/jpb7O3f3jUMYMebZZZrDq5S7om9a6rvB/YCA==",
       "requires": {
-        "@docusaurus/core": "3.0.1",
-        "@docusaurus/mdx-loader": "3.0.1",
-        "@docusaurus/types": "3.0.1",
-        "@docusaurus/utils": "3.0.1",
-        "@docusaurus/utils-validation": "3.0.1",
+        "@docusaurus/core": "3.1.1",
+        "@docusaurus/mdx-loader": "3.1.1",
+        "@docusaurus/types": "3.1.1",
+        "@docusaurus/utils": "3.1.1",
+        "@docusaurus/utils-validation": "3.1.1",
         "fs-extra": "^11.1.1",
         "tslib": "^2.6.0",
         "webpack": "^5.88.1"
       }
     },
     "@docusaurus/plugin-debug": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-debug/-/plugin-debug-3.0.1.tgz",
-      "integrity": "sha512-09dxZMdATky4qdsZGzhzlUvvC+ilQ2hKbYF+wez+cM2mGo4qHbv8+qKXqxq0CQZyimwlAOWQLoSozIXU0g0i7g==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-debug/-/plugin-debug-3.1.1.tgz",
+      "integrity": "sha512-xWeMkueM9wE/8LVvl4+Qf1WqwXmreMjI5Kgr7GYCDoJ8zu4kD+KaMhrh7py7MNM38IFvU1RfrGKacCEe2DRRfQ==",
       "requires": {
-        "@docusaurus/core": "3.0.1",
-        "@docusaurus/types": "3.0.1",
-        "@docusaurus/utils": "3.0.1",
+        "@docusaurus/core": "3.1.1",
+        "@docusaurus/types": "3.1.1",
+        "@docusaurus/utils": "3.1.1",
         "fs-extra": "^11.1.1",
         "react-json-view-lite": "^1.2.0",
         "tslib": "^2.6.0"
       }
     },
     "@docusaurus/plugin-google-analytics": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-analytics/-/plugin-google-analytics-3.0.1.tgz",
-      "integrity": "sha512-jwseSz1E+g9rXQwDdr0ZdYNjn8leZBnKPjjQhMBEiwDoenL3JYFcNW0+p0sWoVF/f2z5t7HkKA+cYObrUh18gg==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-analytics/-/plugin-google-analytics-3.1.1.tgz",
+      "integrity": "sha512-+q2UpWTqVi8GdlLoSlD5bS/YpxW+QMoBwrPrUH/NpvpuOi0Of7MTotsQf9JWd3hymZxl2uu1o3PIrbpxfeDFDQ==",
       "requires": {
-        "@docusaurus/core": "3.0.1",
-        "@docusaurus/types": "3.0.1",
-        "@docusaurus/utils-validation": "3.0.1",
+        "@docusaurus/core": "3.1.1",
+        "@docusaurus/types": "3.1.1",
+        "@docusaurus/utils-validation": "3.1.1",
         "tslib": "^2.6.0"
       }
     },
     "@docusaurus/plugin-google-gtag": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-gtag/-/plugin-google-gtag-3.0.1.tgz",
-      "integrity": "sha512-UFTDvXniAWrajsulKUJ1DB6qplui1BlKLQZjX4F7qS/qfJ+qkKqSkhJ/F4VuGQ2JYeZstYb+KaUzUzvaPK1aRQ==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-gtag/-/plugin-google-gtag-3.1.1.tgz",
+      "integrity": "sha512-0mMPiBBlQ5LFHTtjxuvt/6yzh8v7OxLi3CbeEsxXZpUzcKO/GC7UA1VOWUoBeQzQL508J12HTAlR3IBU9OofSw==",
       "requires": {
-        "@docusaurus/core": "3.0.1",
-        "@docusaurus/types": "3.0.1",
-        "@docusaurus/utils-validation": "3.0.1",
+        "@docusaurus/core": "3.1.1",
+        "@docusaurus/types": "3.1.1",
+        "@docusaurus/utils-validation": "3.1.1",
         "@types/gtag.js": "^0.0.12",
         "tslib": "^2.6.0"
       }
     },
     "@docusaurus/plugin-google-tag-manager": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-tag-manager/-/plugin-google-tag-manager-3.0.1.tgz",
-      "integrity": "sha512-IPFvuz83aFuheZcWpTlAdiiX1RqWIHM+OH8wS66JgwAKOiQMR3+nLywGjkLV4bp52x7nCnwhNk1rE85Cpy/CIw==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-tag-manager/-/plugin-google-tag-manager-3.1.1.tgz",
+      "integrity": "sha512-d07bsrMLdDIryDtY17DgqYUbjkswZQr8cLWl4tzXrt5OR/T/zxC1SYKajzB3fd87zTu5W5klV5GmUwcNSMXQXA==",
       "requires": {
-        "@docusaurus/core": "3.0.1",
-        "@docusaurus/types": "3.0.1",
-        "@docusaurus/utils-validation": "3.0.1",
+        "@docusaurus/core": "3.1.1",
+        "@docusaurus/types": "3.1.1",
+        "@docusaurus/utils-validation": "3.1.1",
         "tslib": "^2.6.0"
       }
     },
     "@docusaurus/plugin-sitemap": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-sitemap/-/plugin-sitemap-3.0.1.tgz",
-      "integrity": "sha512-xARiWnjtVvoEniZudlCq5T9ifnhCu/GAZ5nA7XgyLfPcNpHQa241HZdsTlLtVcecEVVdllevBKOp7qknBBaMGw==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-sitemap/-/plugin-sitemap-3.1.1.tgz",
+      "integrity": "sha512-iJ4hCaMmDaUqRv131XJdt/C/jJQx8UreDWTRqZKtNydvZVh/o4yXGRRFOplea1D9b/zpwL1Y+ZDwX7xMhIOTmg==",
       "requires": {
-        "@docusaurus/core": "3.0.1",
-        "@docusaurus/logger": "3.0.1",
-        "@docusaurus/types": "3.0.1",
-        "@docusaurus/utils": "3.0.1",
-        "@docusaurus/utils-common": "3.0.1",
-        "@docusaurus/utils-validation": "3.0.1",
+        "@docusaurus/core": "3.1.1",
+        "@docusaurus/logger": "3.1.1",
+        "@docusaurus/types": "3.1.1",
+        "@docusaurus/utils": "3.1.1",
+        "@docusaurus/utils-common": "3.1.1",
+        "@docusaurus/utils-validation": "3.1.1",
         "fs-extra": "^11.1.1",
         "sitemap": "^7.1.1",
         "tslib": "^2.6.0"
       }
     },
     "@docusaurus/preset-classic": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/preset-classic/-/preset-classic-3.0.1.tgz",
-      "integrity": "sha512-il9m9xZKKjoXn6h0cRcdnt6wce0Pv1y5t4xk2Wx7zBGhKG1idu4IFHtikHlD0QPuZ9fizpXspXcTzjL5FXc1Gw==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/preset-classic/-/preset-classic-3.1.1.tgz",
+      "integrity": "sha512-jG4ys/hWYf69iaN/xOmF+3kjs4Nnz1Ay3CjFLDtYa8KdxbmUhArA9HmP26ru5N0wbVWhY+6kmpYhTJpez5wTyg==",
       "requires": {
-        "@docusaurus/core": "3.0.1",
-        "@docusaurus/plugin-content-blog": "3.0.1",
-        "@docusaurus/plugin-content-docs": "3.0.1",
-        "@docusaurus/plugin-content-pages": "3.0.1",
-        "@docusaurus/plugin-debug": "3.0.1",
-        "@docusaurus/plugin-google-analytics": "3.0.1",
-        "@docusaurus/plugin-google-gtag": "3.0.1",
-        "@docusaurus/plugin-google-tag-manager": "3.0.1",
-        "@docusaurus/plugin-sitemap": "3.0.1",
-        "@docusaurus/theme-classic": "3.0.1",
-        "@docusaurus/theme-common": "3.0.1",
-        "@docusaurus/theme-search-algolia": "3.0.1",
-        "@docusaurus/types": "3.0.1"
+        "@docusaurus/core": "3.1.1",
+        "@docusaurus/plugin-content-blog": "3.1.1",
+        "@docusaurus/plugin-content-docs": "3.1.1",
+        "@docusaurus/plugin-content-pages": "3.1.1",
+        "@docusaurus/plugin-debug": "3.1.1",
+        "@docusaurus/plugin-google-analytics": "3.1.1",
+        "@docusaurus/plugin-google-gtag": "3.1.1",
+        "@docusaurus/plugin-google-tag-manager": "3.1.1",
+        "@docusaurus/plugin-sitemap": "3.1.1",
+        "@docusaurus/theme-classic": "3.1.1",
+        "@docusaurus/theme-common": "3.1.1",
+        "@docusaurus/theme-search-algolia": "3.1.1",
+        "@docusaurus/types": "3.1.1"
       }
     },
     "@docusaurus/react-loadable": {
@@ -16572,22 +16574,22 @@
       }
     },
     "@docusaurus/theme-classic": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-classic/-/theme-classic-3.0.1.tgz",
-      "integrity": "sha512-XD1FRXaJiDlmYaiHHdm27PNhhPboUah9rqIH0lMpBt5kYtsGjJzhqa27KuZvHLzOP2OEpqd2+GZ5b6YPq7Q05Q==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-classic/-/theme-classic-3.1.1.tgz",
+      "integrity": "sha512-GiPE/jbWM8Qv1A14lk6s9fhc0LhPEQ00eIczRO4QL2nAQJZXkjPG6zaVx+1cZxPFWbAsqSjKe2lqkwF3fGkQ7Q==",
       "requires": {
-        "@docusaurus/core": "3.0.1",
-        "@docusaurus/mdx-loader": "3.0.1",
-        "@docusaurus/module-type-aliases": "3.0.1",
-        "@docusaurus/plugin-content-blog": "3.0.1",
-        "@docusaurus/plugin-content-docs": "3.0.1",
-        "@docusaurus/plugin-content-pages": "3.0.1",
-        "@docusaurus/theme-common": "3.0.1",
-        "@docusaurus/theme-translations": "3.0.1",
-        "@docusaurus/types": "3.0.1",
-        "@docusaurus/utils": "3.0.1",
-        "@docusaurus/utils-common": "3.0.1",
-        "@docusaurus/utils-validation": "3.0.1",
+        "@docusaurus/core": "3.1.1",
+        "@docusaurus/mdx-loader": "3.1.1",
+        "@docusaurus/module-type-aliases": "3.1.1",
+        "@docusaurus/plugin-content-blog": "3.1.1",
+        "@docusaurus/plugin-content-docs": "3.1.1",
+        "@docusaurus/plugin-content-pages": "3.1.1",
+        "@docusaurus/theme-common": "3.1.1",
+        "@docusaurus/theme-translations": "3.1.1",
+        "@docusaurus/types": "3.1.1",
+        "@docusaurus/utils": "3.1.1",
+        "@docusaurus/utils-common": "3.1.1",
+        "@docusaurus/utils-validation": "3.1.1",
         "@mdx-js/react": "^3.0.0",
         "clsx": "^2.0.0",
         "copy-text-to-clipboard": "^3.2.0",
@@ -16604,17 +16606,17 @@
       }
     },
     "@docusaurus/theme-common": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-common/-/theme-common-3.0.1.tgz",
-      "integrity": "sha512-cr9TOWXuIOL0PUfuXv6L5lPlTgaphKP+22NdVBOYah5jSq5XAAulJTjfe+IfLsEG4L7lJttLbhW7LXDFSAI7Ag==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-common/-/theme-common-3.1.1.tgz",
+      "integrity": "sha512-38urZfeMhN70YaXkwIGXmcUcv2CEYK/2l4b05GkJPrbEbgpsIZM3Xc+Js2ehBGGZmfZq8GjjQ5RNQYG+MYzCYg==",
       "requires": {
-        "@docusaurus/mdx-loader": "3.0.1",
-        "@docusaurus/module-type-aliases": "3.0.1",
-        "@docusaurus/plugin-content-blog": "3.0.1",
-        "@docusaurus/plugin-content-docs": "3.0.1",
-        "@docusaurus/plugin-content-pages": "3.0.1",
-        "@docusaurus/utils": "3.0.1",
-        "@docusaurus/utils-common": "3.0.1",
+        "@docusaurus/mdx-loader": "3.1.1",
+        "@docusaurus/module-type-aliases": "3.1.1",
+        "@docusaurus/plugin-content-blog": "3.1.1",
+        "@docusaurus/plugin-content-docs": "3.1.1",
+        "@docusaurus/plugin-content-pages": "3.1.1",
+        "@docusaurus/utils": "3.1.1",
+        "@docusaurus/utils-common": "3.1.1",
         "@types/history": "^4.7.11",
         "@types/react": "*",
         "@types/react-router-config": "*",
@@ -16626,18 +16628,18 @@
       }
     },
     "@docusaurus/theme-search-algolia": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-search-algolia/-/theme-search-algolia-3.0.1.tgz",
-      "integrity": "sha512-DDiPc0/xmKSEdwFkXNf1/vH1SzJPzuJBar8kMcBbDAZk/SAmo/4lf6GU2drou4Ae60lN2waix+jYWTWcJRahSA==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-search-algolia/-/theme-search-algolia-3.1.1.tgz",
+      "integrity": "sha512-tBH9VY5EpRctVdaAhT+b1BY8y5dyHVZGFXyCHgTrvcXQy5CV4q7serEX7U3SveNT9zksmchPyct6i1sFDC4Z5g==",
       "requires": {
         "@docsearch/react": "^3.5.2",
-        "@docusaurus/core": "3.0.1",
-        "@docusaurus/logger": "3.0.1",
-        "@docusaurus/plugin-content-docs": "3.0.1",
-        "@docusaurus/theme-common": "3.0.1",
-        "@docusaurus/theme-translations": "3.0.1",
-        "@docusaurus/utils": "3.0.1",
-        "@docusaurus/utils-validation": "3.0.1",
+        "@docusaurus/core": "3.1.1",
+        "@docusaurus/logger": "3.1.1",
+        "@docusaurus/plugin-content-docs": "3.1.1",
+        "@docusaurus/theme-common": "3.1.1",
+        "@docusaurus/theme-translations": "3.1.1",
+        "@docusaurus/utils": "3.1.1",
+        "@docusaurus/utils-validation": "3.1.1",
         "algoliasearch": "^4.18.0",
         "algoliasearch-helper": "^3.13.3",
         "clsx": "^2.0.0",
@@ -16649,19 +16651,20 @@
       }
     },
     "@docusaurus/theme-translations": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-translations/-/theme-translations-3.0.1.tgz",
-      "integrity": "sha512-6UrbpzCTN6NIJnAtZ6Ne9492vmPVX+7Fsz4kmp+yor3KQwA1+MCzQP7ItDNkP38UmVLnvB/cYk/IvehCUqS3dg==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-translations/-/theme-translations-3.1.1.tgz",
+      "integrity": "sha512-xvWQFwjxHphpJq5fgk37FXCDdAa2o+r7FX8IpMg+bGZBNXyWBu3MjZ+G4+eUVNpDhVinTc+j6ucL0Ain5KCGrg==",
       "requires": {
         "fs-extra": "^11.1.1",
         "tslib": "^2.6.0"
       }
     },
     "@docusaurus/types": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-3.0.1.tgz",
-      "integrity": "sha512-plyX2iU1tcUsF46uQ01pAd4JhexR7n0iiQ5MSnBFX6M6NSJgDYdru/i1/YNPKOnQHBoXGLHv0dNT6OAlDWNjrg==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-3.1.1.tgz",
+      "integrity": "sha512-grBqOLnubUecgKFXN9q3uit2HFbCxTWX4Fam3ZFbMN0sWX9wOcDoA7lwdX/8AmeL20Oc4kQvWVgNrsT8bKRvzg==",
       "requires": {
+        "@mdx-js/mdx": "^3.0.0",
         "@types/history": "^4.7.11",
         "@types/react": "*",
         "commander": "^5.1.0",
@@ -16673,11 +16676,11 @@
       }
     },
     "@docusaurus/utils": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils/-/utils-3.0.1.tgz",
-      "integrity": "sha512-TwZ33Am0q4IIbvjhUOs+zpjtD/mXNmLmEgeTGuRq01QzulLHuPhaBTTAC/DHu6kFx3wDgmgpAlaRuCHfTcXv8g==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/utils/-/utils-3.1.1.tgz",
+      "integrity": "sha512-ZJfJa5cJQtRYtqijsPEnAZoduW6sjAQ7ZCWSZavLcV10Fw0Z3gSaPKA/B4micvj2afRZ4gZxT7KfYqe5H8Cetg==",
       "requires": {
-        "@docusaurus/logger": "3.0.1",
+        "@docusaurus/logger": "3.1.1",
         "@svgr/webpack": "^6.5.1",
         "escape-string-regexp": "^4.0.0",
         "file-loader": "^6.2.0",
@@ -16697,20 +16700,20 @@
       }
     },
     "@docusaurus/utils-common": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils-common/-/utils-common-3.0.1.tgz",
-      "integrity": "sha512-W0AxD6w6T8g6bNro8nBRWf7PeZ/nn7geEWM335qHU2DDDjHuV4UZjgUGP1AQsdcSikPrlIqTJJbKzer1lRSlIg==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/utils-common/-/utils-common-3.1.1.tgz",
+      "integrity": "sha512-eGne3olsIoNfPug5ixjepZAIxeYFzHHnor55Wb2P57jNbtVaFvij/T+MS8U0dtZRFi50QU+UPmRrXdVUM8uyMg==",
       "requires": {
         "tslib": "^2.6.0"
       }
     },
     "@docusaurus/utils-validation": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils-validation/-/utils-validation-3.0.1.tgz",
-      "integrity": "sha512-ujTnqSfyGQ7/4iZdB4RRuHKY/Nwm58IIb+41s5tCXOv/MBU2wGAjOHq3U+AEyJ8aKQcHbxvTKJaRchNHYUVUQg==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/utils-validation/-/utils-validation-3.1.1.tgz",
+      "integrity": "sha512-KlY4P9YVDnwL+nExvlIpu79abfEv6ZCHuOX4ZQ+gtip+Wxj0daccdReIWWtqxM/Fb5Cz1nQvUCc7VEtT8IBUAA==",
       "requires": {
-        "@docusaurus/logger": "3.0.1",
-        "@docusaurus/utils": "3.0.1",
+        "@docusaurus/logger": "3.1.1",
+        "@docusaurus/utils": "3.1.1",
         "joi": "^17.9.2",
         "js-yaml": "^4.1.0",
         "tslib": "^2.6.0"
@@ -16895,9 +16898,9 @@
       "integrity": "sha512-2LuNTFBIO0m7kKIQvvPHN6UE63VjpmL9rnEEaOOaiSPbZK+zUOYIzBAWcED+3XYzhYsd/0mD57VdxAEqqV52CQ=="
     },
     "@sideway/address": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@sideway/address/-/address-4.1.4.tgz",
-      "integrity": "sha512-7vwq+rOHVWjyXxVlR76Agnvhy8I9rpzjosTESvmhNeXOXdZZB15Fl+TI9x1SiHZH5Jv2wTGduSxFDIaq0m3DUw==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@sideway/address/-/address-4.1.5.tgz",
+      "integrity": "sha512-IqO/DUQHUkPeixNQ8n0JA6102hT9CmaljNTPmQ1u8MEhBo/R4Q8eKLN/vGZxuebwOroDB4cbpjheD4+/sKFK4Q==",
       "requires": {
         "@hapi/hoek": "^9.0.0"
       }
@@ -17661,30 +17664,30 @@
       }
     },
     "algoliasearch": {
-      "version": "4.22.0",
-      "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-4.22.0.tgz",
-      "integrity": "sha512-gfceltjkwh7PxXwtkS8KVvdfK+TSNQAWUeNSxf4dA29qW5tf2EGwa8jkJujlT9jLm17cixMVoGNc+GJFO1Mxhg==",
+      "version": "4.22.1",
+      "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-4.22.1.tgz",
+      "integrity": "sha512-jwydKFQJKIx9kIZ8Jm44SdpigFwRGPESaxZBaHSV0XWN2yBJAOT4mT7ppvlrpA4UGzz92pqFnVKr/kaZXrcreg==",
       "requires": {
-        "@algolia/cache-browser-local-storage": "4.22.0",
-        "@algolia/cache-common": "4.22.0",
-        "@algolia/cache-in-memory": "4.22.0",
-        "@algolia/client-account": "4.22.0",
-        "@algolia/client-analytics": "4.22.0",
-        "@algolia/client-common": "4.22.0",
-        "@algolia/client-personalization": "4.22.0",
-        "@algolia/client-search": "4.22.0",
-        "@algolia/logger-common": "4.22.0",
-        "@algolia/logger-console": "4.22.0",
-        "@algolia/requester-browser-xhr": "4.22.0",
-        "@algolia/requester-common": "4.22.0",
-        "@algolia/requester-node-http": "4.22.0",
-        "@algolia/transporter": "4.22.0"
+        "@algolia/cache-browser-local-storage": "4.22.1",
+        "@algolia/cache-common": "4.22.1",
+        "@algolia/cache-in-memory": "4.22.1",
+        "@algolia/client-account": "4.22.1",
+        "@algolia/client-analytics": "4.22.1",
+        "@algolia/client-common": "4.22.1",
+        "@algolia/client-personalization": "4.22.1",
+        "@algolia/client-search": "4.22.1",
+        "@algolia/logger-common": "4.22.1",
+        "@algolia/logger-console": "4.22.1",
+        "@algolia/requester-browser-xhr": "4.22.1",
+        "@algolia/requester-common": "4.22.1",
+        "@algolia/requester-node-http": "4.22.1",
+        "@algolia/transporter": "4.22.1"
       }
     },
     "algoliasearch-helper": {
-      "version": "3.16.0",
-      "resolved": "https://registry.npmjs.org/algoliasearch-helper/-/algoliasearch-helper-3.16.0.tgz",
-      "integrity": "sha512-RxOtBafSQwyqD5BLO/q9VsVw/zuNz8kjb51OZhCIWLr33uvKB+vrRis+QK+JFlNQXbXf+w28fsTWiBupc1pHew==",
+      "version": "3.16.2",
+      "resolved": "https://registry.npmjs.org/algoliasearch-helper/-/algoliasearch-helper-3.16.2.tgz",
+      "integrity": "sha512-Yl/Gu5Cq4Z5s/AJ0jR37OPI1H3+z7PHz657ibyaXgMOaWvPlZ3OACN13N+7HCLPUlB0BN+8BtmrG/CqTilowBA==",
       "requires": {
         "@algolia/events": "^4.0.1"
       }
@@ -19800,9 +19803,9 @@
       }
     },
     "hast-util-raw": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/hast-util-raw/-/hast-util-raw-9.0.1.tgz",
-      "integrity": "sha512-5m1gmba658Q+lO5uqL5YNGQWeh1MYWZbZmWrM5lncdcuiXuo5E2HT/CIOp0rLF8ksfSwiCVJ3twlgVRyTGThGA==",
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/hast-util-raw/-/hast-util-raw-9.0.2.tgz",
+      "integrity": "sha512-PldBy71wO9Uq1kyaMch9AHIghtQvIwxBUkv823pKmkTM3oV1JxtsTNYdevMxvUHqcnOAuO65JKU2+0NOxc2ksA==",
       "requires": {
         "@types/hast": "^3.0.0",
         "@types/unist": "^3.0.0",
@@ -20159,9 +20162,9 @@
       "integrity": "sha512-g7dmpshy+gD7mh88OC9NwSGTKoc3kyLAZQRU1mt53Aw/vnvfXnbC+F/7F7QoYVKbV+KNvJx8wArewKy1vXMtlg=="
     },
     "image-size": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/image-size/-/image-size-1.0.2.tgz",
-      "integrity": "sha512-xfOoWjceHntRb3qFCrh5ZFORYH8XCdYpASltMhZ/Q0KZiOwjdE/Yl2QCiWdwD+lygV5bMCvauzgu5PxBX/Yerg==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/image-size/-/image-size-1.1.1.tgz",
+      "integrity": "sha512-541xKlUw6jr/6gGuk92F+mYM5zaFAc5ahphvkqvNe2bQ6gVBkd6bfrmVJ2t4KDAfikAYZyIqTnktX3i6/aQDrQ==",
       "requires": {
         "queue": "6.0.2"
       }
@@ -20463,13 +20466,13 @@
       "integrity": "sha512-gFqAIbuKyyso/3G2qhiO2OM6shY6EPP/R0+mkDbyspxKazh8BXDC5FiFsUjlczgdNz/vfra0da2y+aHrusLG/Q=="
     },
     "joi": {
-      "version": "17.11.0",
-      "resolved": "https://registry.npmjs.org/joi/-/joi-17.11.0.tgz",
-      "integrity": "sha512-NgB+lZLNoqISVy1rZocE9PZI36bL/77ie924Ri43yEvi9GUUMPeyVIr8KdFTMUlby1p0PBYMk9spIxEUQYqrJQ==",
+      "version": "17.12.1",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-17.12.1.tgz",
+      "integrity": "sha512-vtxmq+Lsc5SlfqotnfVjlViWfOL9nt/avKNbKYizwf6gsCfq9NYY/ceYRMFD8XDdrjJ9abJyScWmhmIiy+XRtQ==",
       "requires": {
-        "@hapi/hoek": "^9.0.0",
-        "@hapi/topo": "^5.0.0",
-        "@sideway/address": "^4.1.3",
+        "@hapi/hoek": "^9.3.0",
+        "@hapi/topo": "^5.1.0",
+        "@sideway/address": "^4.1.5",
         "@sideway/formula": "^3.0.1",
         "@sideway/pinpoint": "^2.0.0"
       }
@@ -20764,9 +20767,9 @@
       },
       "dependencies": {
         "micromark-util-character": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.0.1.tgz",
-          "integrity": "sha512-3wgnrmEAJ4T+mGXAUfMvMAbxU9RDG43XmGce4j6CwPtVxB3vfwXSZ6KhFwDzZ3mZHhmPimMAXg71veiBGzeAZw==",
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.0.tgz",
+          "integrity": "sha512-KvOVV+X1yLBfs9dCBSopq/+G1PcgT3lAK07mC4BzXi5E7ahzMAF8oIupDDJ6mievI6F+lAATkbQQlQixJfT3aQ==",
           "requires": {
             "micromark-util-symbol": "^2.0.0",
             "micromark-util-types": "^2.0.0"
@@ -20892,9 +20895,9 @@
       }
     },
     "mdast-util-to-hast": {
-      "version": "13.0.2",
-      "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-13.0.2.tgz",
-      "integrity": "sha512-U5I+500EOOw9e3ZrclN3Is3fRpw8c19SMyNZlZ2IS+7vLsNzb2Om11VpIVOR+/0137GhZsFEF6YiKD5+0Hr2Og==",
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-13.1.0.tgz",
+      "integrity": "sha512-/e2l/6+OdGp/FB+ctrJ9Avz71AN/GRH3oi/3KAx/kMnoUsD6q0woXlDT8lLEeViVKE7oZxE7RXzvO3T8kF2/sA==",
       "requires": {
         "@types/hast": "^3.0.0",
         "@types/mdast": "^4.0.0",
@@ -20903,7 +20906,8 @@
         "micromark-util-sanitize-uri": "^2.0.0",
         "trim-lines": "^3.0.0",
         "unist-util-position": "^5.0.0",
-        "unist-util-visit": "^5.0.0"
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0"
       }
     },
     "mdast-util-to-markdown": {
@@ -21001,9 +21005,9 @@
           }
         },
         "micromark-util-character": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.0.1.tgz",
-          "integrity": "sha512-3wgnrmEAJ4T+mGXAUfMvMAbxU9RDG43XmGce4j6CwPtVxB3vfwXSZ6KhFwDzZ3mZHhmPimMAXg71veiBGzeAZw==",
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.0.tgz",
+          "integrity": "sha512-KvOVV+X1yLBfs9dCBSopq/+G1PcgT3lAK07mC4BzXi5E7ahzMAF8oIupDDJ6mievI6F+lAATkbQQlQixJfT3aQ==",
           "requires": {
             "micromark-util-symbol": "^2.0.0",
             "micromark-util-types": "^2.0.0"
@@ -21049,9 +21053,9 @@
           }
         },
         "micromark-util-character": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.0.1.tgz",
-          "integrity": "sha512-3wgnrmEAJ4T+mGXAUfMvMAbxU9RDG43XmGce4j6CwPtVxB3vfwXSZ6KhFwDzZ3mZHhmPimMAXg71veiBGzeAZw==",
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.0.tgz",
+          "integrity": "sha512-KvOVV+X1yLBfs9dCBSopq/+G1PcgT3lAK07mC4BzXi5E7ahzMAF8oIupDDJ6mievI6F+lAATkbQQlQixJfT3aQ==",
           "requires": {
             "micromark-util-symbol": "^2.0.0",
             "micromark-util-types": "^2.0.0"
@@ -21088,9 +21092,9 @@
           }
         },
         "micromark-util-character": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.0.1.tgz",
-          "integrity": "sha512-3wgnrmEAJ4T+mGXAUfMvMAbxU9RDG43XmGce4j6CwPtVxB3vfwXSZ6KhFwDzZ3mZHhmPimMAXg71veiBGzeAZw==",
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.0.tgz",
+          "integrity": "sha512-KvOVV+X1yLBfs9dCBSopq/+G1PcgT3lAK07mC4BzXi5E7ahzMAF8oIupDDJ6mievI6F+lAATkbQQlQixJfT3aQ==",
           "requires": {
             "micromark-util-symbol": "^2.0.0",
             "micromark-util-types": "^2.0.0"
@@ -21115,9 +21119,9 @@
       },
       "dependencies": {
         "micromark-util-character": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.0.1.tgz",
-          "integrity": "sha512-3wgnrmEAJ4T+mGXAUfMvMAbxU9RDG43XmGce4j6CwPtVxB3vfwXSZ6KhFwDzZ3mZHhmPimMAXg71veiBGzeAZw==",
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.0.tgz",
+          "integrity": "sha512-KvOVV+X1yLBfs9dCBSopq/+G1PcgT3lAK07mC4BzXi5E7ahzMAF8oIupDDJ6mievI6F+lAATkbQQlQixJfT3aQ==",
           "requires": {
             "micromark-util-symbol": "^2.0.0",
             "micromark-util-types": "^2.0.0"
@@ -21157,9 +21161,9 @@
       },
       "dependencies": {
         "micromark-util-character": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.0.1.tgz",
-          "integrity": "sha512-3wgnrmEAJ4T+mGXAUfMvMAbxU9RDG43XmGce4j6CwPtVxB3vfwXSZ6KhFwDzZ3mZHhmPimMAXg71veiBGzeAZw==",
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.0.tgz",
+          "integrity": "sha512-KvOVV+X1yLBfs9dCBSopq/+G1PcgT3lAK07mC4BzXi5E7ahzMAF8oIupDDJ6mievI6F+lAATkbQQlQixJfT3aQ==",
           "requires": {
             "micromark-util-symbol": "^2.0.0",
             "micromark-util-types": "^2.0.0"
@@ -21197,9 +21201,9 @@
           }
         },
         "micromark-util-character": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.0.1.tgz",
-          "integrity": "sha512-3wgnrmEAJ4T+mGXAUfMvMAbxU9RDG43XmGce4j6CwPtVxB3vfwXSZ6KhFwDzZ3mZHhmPimMAXg71veiBGzeAZw==",
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.0.tgz",
+          "integrity": "sha512-KvOVV+X1yLBfs9dCBSopq/+G1PcgT3lAK07mC4BzXi5E7ahzMAF8oIupDDJ6mievI6F+lAATkbQQlQixJfT3aQ==",
           "requires": {
             "micromark-util-symbol": "^2.0.0",
             "micromark-util-types": "^2.0.0"
@@ -21254,9 +21258,9 @@
           }
         },
         "micromark-util-character": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.0.1.tgz",
-          "integrity": "sha512-3wgnrmEAJ4T+mGXAUfMvMAbxU9RDG43XmGce4j6CwPtVxB3vfwXSZ6KhFwDzZ3mZHhmPimMAXg71veiBGzeAZw==",
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.0.tgz",
+          "integrity": "sha512-KvOVV+X1yLBfs9dCBSopq/+G1PcgT3lAK07mC4BzXi5E7ahzMAF8oIupDDJ6mievI6F+lAATkbQQlQixJfT3aQ==",
           "requires": {
             "micromark-util-symbol": "^2.0.0",
             "micromark-util-types": "^2.0.0"
@@ -21299,9 +21303,9 @@
           }
         },
         "micromark-util-character": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.0.1.tgz",
-          "integrity": "sha512-3wgnrmEAJ4T+mGXAUfMvMAbxU9RDG43XmGce4j6CwPtVxB3vfwXSZ6KhFwDzZ3mZHhmPimMAXg71veiBGzeAZw==",
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.0.tgz",
+          "integrity": "sha512-KvOVV+X1yLBfs9dCBSopq/+G1PcgT3lAK07mC4BzXi5E7ahzMAF8oIupDDJ6mievI6F+lAATkbQQlQixJfT3aQ==",
           "requires": {
             "micromark-util-symbol": "^2.0.0",
             "micromark-util-types": "^2.0.0"
@@ -21339,9 +21343,9 @@
           }
         },
         "micromark-util-character": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.0.1.tgz",
-          "integrity": "sha512-3wgnrmEAJ4T+mGXAUfMvMAbxU9RDG43XmGce4j6CwPtVxB3vfwXSZ6KhFwDzZ3mZHhmPimMAXg71veiBGzeAZw==",
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.0.tgz",
+          "integrity": "sha512-KvOVV+X1yLBfs9dCBSopq/+G1PcgT3lAK07mC4BzXi5E7ahzMAF8oIupDDJ6mievI6F+lAATkbQQlQixJfT3aQ==",
           "requires": {
             "micromark-util-symbol": "^2.0.0",
             "micromark-util-types": "^2.0.0"
@@ -21381,9 +21385,9 @@
           }
         },
         "micromark-util-character": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.0.1.tgz",
-          "integrity": "sha512-3wgnrmEAJ4T+mGXAUfMvMAbxU9RDG43XmGce4j6CwPtVxB3vfwXSZ6KhFwDzZ3mZHhmPimMAXg71veiBGzeAZw==",
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.0.tgz",
+          "integrity": "sha512-KvOVV+X1yLBfs9dCBSopq/+G1PcgT3lAK07mC4BzXi5E7ahzMAF8oIupDDJ6mievI6F+lAATkbQQlQixJfT3aQ==",
           "requires": {
             "micromark-util-symbol": "^2.0.0",
             "micromark-util-types": "^2.0.0"
@@ -21436,9 +21440,9 @@
       },
       "dependencies": {
         "micromark-util-character": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.0.1.tgz",
-          "integrity": "sha512-3wgnrmEAJ4T+mGXAUfMvMAbxU9RDG43XmGce4j6CwPtVxB3vfwXSZ6KhFwDzZ3mZHhmPimMAXg71veiBGzeAZw==",
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.0.tgz",
+          "integrity": "sha512-KvOVV+X1yLBfs9dCBSopq/+G1PcgT3lAK07mC4BzXi5E7ahzMAF8oIupDDJ6mievI6F+lAATkbQQlQixJfT3aQ==",
           "requires": {
             "micromark-util-symbol": "^2.0.0",
             "micromark-util-types": "^2.0.0"
@@ -21462,9 +21466,9 @@
       },
       "dependencies": {
         "micromark-util-character": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.0.1.tgz",
-          "integrity": "sha512-3wgnrmEAJ4T+mGXAUfMvMAbxU9RDG43XmGce4j6CwPtVxB3vfwXSZ6KhFwDzZ3mZHhmPimMAXg71veiBGzeAZw==",
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.0.tgz",
+          "integrity": "sha512-KvOVV+X1yLBfs9dCBSopq/+G1PcgT3lAK07mC4BzXi5E7ahzMAF8oIupDDJ6mievI6F+lAATkbQQlQixJfT3aQ==",
           "requires": {
             "micromark-util-symbol": "^2.0.0",
             "micromark-util-types": "^2.0.0"
@@ -21489,9 +21493,9 @@
       },
       "dependencies": {
         "micromark-util-character": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.0.1.tgz",
-          "integrity": "sha512-3wgnrmEAJ4T+mGXAUfMvMAbxU9RDG43XmGce4j6CwPtVxB3vfwXSZ6KhFwDzZ3mZHhmPimMAXg71veiBGzeAZw==",
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.0.tgz",
+          "integrity": "sha512-KvOVV+X1yLBfs9dCBSopq/+G1PcgT3lAK07mC4BzXi5E7ahzMAF8oIupDDJ6mievI6F+lAATkbQQlQixJfT3aQ==",
           "requires": {
             "micromark-util-symbol": "^2.0.0",
             "micromark-util-types": "^2.0.0"
@@ -21520,9 +21524,9 @@
       },
       "dependencies": {
         "micromark-util-character": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.0.1.tgz",
-          "integrity": "sha512-3wgnrmEAJ4T+mGXAUfMvMAbxU9RDG43XmGce4j6CwPtVxB3vfwXSZ6KhFwDzZ3mZHhmPimMAXg71veiBGzeAZw==",
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.0.tgz",
+          "integrity": "sha512-KvOVV+X1yLBfs9dCBSopq/+G1PcgT3lAK07mC4BzXi5E7ahzMAF8oIupDDJ6mievI6F+lAATkbQQlQixJfT3aQ==",
           "requires": {
             "micromark-util-symbol": "^2.0.0",
             "micromark-util-types": "^2.0.0"
@@ -21572,9 +21576,9 @@
           }
         },
         "micromark-util-character": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.0.1.tgz",
-          "integrity": "sha512-3wgnrmEAJ4T+mGXAUfMvMAbxU9RDG43XmGce4j6CwPtVxB3vfwXSZ6KhFwDzZ3mZHhmPimMAXg71veiBGzeAZw==",
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.0.tgz",
+          "integrity": "sha512-KvOVV+X1yLBfs9dCBSopq/+G1PcgT3lAK07mC4BzXi5E7ahzMAF8oIupDDJ6mievI6F+lAATkbQQlQixJfT3aQ==",
           "requires": {
             "micromark-util-symbol": "^2.0.0",
             "micromark-util-types": "^2.0.0"
@@ -21608,9 +21612,9 @@
           }
         },
         "micromark-util-character": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.0.1.tgz",
-          "integrity": "sha512-3wgnrmEAJ4T+mGXAUfMvMAbxU9RDG43XmGce4j6CwPtVxB3vfwXSZ6KhFwDzZ3mZHhmPimMAXg71veiBGzeAZw==",
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.0.tgz",
+          "integrity": "sha512-KvOVV+X1yLBfs9dCBSopq/+G1PcgT3lAK07mC4BzXi5E7ahzMAF8oIupDDJ6mievI6F+lAATkbQQlQixJfT3aQ==",
           "requires": {
             "micromark-util-symbol": "^2.0.0",
             "micromark-util-types": "^2.0.0"
@@ -21665,9 +21669,9 @@
       },
       "dependencies": {
         "micromark-util-character": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.0.1.tgz",
-          "integrity": "sha512-3wgnrmEAJ4T+mGXAUfMvMAbxU9RDG43XmGce4j6CwPtVxB3vfwXSZ6KhFwDzZ3mZHhmPimMAXg71veiBGzeAZw==",
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.0.tgz",
+          "integrity": "sha512-KvOVV+X1yLBfs9dCBSopq/+G1PcgT3lAK07mC4BzXi5E7ahzMAF8oIupDDJ6mievI6F+lAATkbQQlQixJfT3aQ==",
           "requires": {
             "micromark-util-symbol": "^2.0.0",
             "micromark-util-types": "^2.0.0"
@@ -21716,9 +21720,9 @@
       },
       "dependencies": {
         "micromark-util-character": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.0.1.tgz",
-          "integrity": "sha512-3wgnrmEAJ4T+mGXAUfMvMAbxU9RDG43XmGce4j6CwPtVxB3vfwXSZ6KhFwDzZ3mZHhmPimMAXg71veiBGzeAZw==",
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.0.tgz",
+          "integrity": "sha512-KvOVV+X1yLBfs9dCBSopq/+G1PcgT3lAK07mC4BzXi5E7ahzMAF8oIupDDJ6mievI6F+lAATkbQQlQixJfT3aQ==",
           "requires": {
             "micromark-util-symbol": "^2.0.0",
             "micromark-util-types": "^2.0.0"
@@ -21797,9 +21801,9 @@
       },
       "dependencies": {
         "micromark-util-character": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.0.1.tgz",
-          "integrity": "sha512-3wgnrmEAJ4T+mGXAUfMvMAbxU9RDG43XmGce4j6CwPtVxB3vfwXSZ6KhFwDzZ3mZHhmPimMAXg71veiBGzeAZw==",
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.0.tgz",
+          "integrity": "sha512-KvOVV+X1yLBfs9dCBSopq/+G1PcgT3lAK07mC4BzXi5E7ahzMAF8oIupDDJ6mievI6F+lAATkbQQlQixJfT3aQ==",
           "requires": {
             "micromark-util-symbol": "^2.0.0",
             "micromark-util-types": "^2.0.0"
@@ -22765,9 +22769,9 @@
       }
     },
     "property-information": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/property-information/-/property-information-6.4.0.tgz",
-      "integrity": "sha512-9t5qARVofg2xQqKtytzt+lZ4d1Qvj8t5B8fEwXK6qOfgRLgH/b13QlgEyDh033NOS31nXeFbYv7CLUDG1CeifQ=="
+      "version": "6.4.1",
+      "resolved": "https://registry.npmjs.org/property-information/-/property-information-6.4.1.tgz",
+      "integrity": "sha512-OHYtXfu5aI2sS2LWFSN5rgJjrQ4pCy8i1jubJLe2QvMF8JJ++HXTUIVWFLfXJoaOfvYYjk2SN8J2wFUWIGXT4w=="
     },
     "proto-list": {
       "version": "1.2.4",
@@ -23256,9 +23260,9 @@
       }
     },
     "remark-rehype": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/remark-rehype/-/remark-rehype-11.0.0.tgz",
-      "integrity": "sha512-vx8x2MDMcxuE4lBmQ46zYUDfcFMmvg80WYX+UNLeG6ixjdCCLcw1lrgAukwBTuOFsS78eoAedHGn9sNM0w7TPw==",
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/remark-rehype/-/remark-rehype-11.1.0.tgz",
+      "integrity": "sha512-z3tJrAs2kIs1AqIIy6pzHmAHlF1hWQ+OdY4/hv+Wxe35EhyLKcajL33iUEn3ScxtFox9nUvRufR/Zre8Q08H/g==",
       "requires": {
         "@types/hast": "^3.0.0",
         "@types/mdast": "^4.0.0",
@@ -24542,9 +24546,9 @@
       "integrity": "sha512-Z0DbgELS9/L/75wZbro8xAnT50pBVFQZ+hUEueGDU5FN51YSCYM+jdxsfCiHjwNP/4LCDD0i/graKpeBnOXKRA=="
     },
     "utility-types": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/utility-types/-/utility-types-3.10.0.tgz",
-      "integrity": "sha512-O11mqxmi7wMKCo6HKFt5AhO4BwY3VV68YU07tgxfz8zJTIxr4BpsezN49Ffwy9j3ZpwwJp4fkRwjRzq3uWE6Rg=="
+      "version": "3.11.0",
+      "resolved": "https://registry.npmjs.org/utility-types/-/utility-types-3.11.0.tgz",
+      "integrity": "sha512-6Z7Ma2aVEWisaL6TvBCy7P8rm2LQoPv6dJ7ecIaIixHcwfbJ0x7mWdbcwlIM5IGQxPZSFYeqRCqlOOeKoJYMkw=="
     },
     "utils-merge": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -18,8 +18,8 @@
   },
   "dependencies": {
     "@crowdin/cli": "^3.14.0",
-    "@docusaurus/core": "3.0.1",
-    "@docusaurus/preset-classic": "3.0.1",
+    "@docusaurus/core": "3.1.1",
+    "@docusaurus/preset-classic": "3.1.1",
     "@mdx-js/react": "^3.0.0",
     "autoprefixer": "^10.4.14",
     "clsx": "^2.0.0",
@@ -29,7 +29,7 @@
     "react-dom": "^18.2.0"
   },
   "devDependencies": {
-    "@docusaurus/module-type-aliases": "3.0.1"
+    "@docusaurus/module-type-aliases": "3.1.1"
   },
   "browserslist": {
     "production": [


### PR DESCRIPTION
Try to find out why the dependabot bumps don't work (probably because every docusaurus plugin version should be updated at once).