### PR TITLE
chore: Use actions/deploy-pages in deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -23,11 +23,10 @@ jobs:
       - name: Build website
         run: npm run build
 
-      # Popular action to deploy to GitHub Pages:
-      # Docs: https://github.com/peaceiris/actions-gh-pages#%EF%B8%8F-docusaurus
-      - name: Deploy to GitHub Pages
-        uses: peaceiris/actions-gh-pages@v3
+      - uses: actions/configure-pages@v4
+      - uses: actions/upload-pages-artifact@v2
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          # Build output to publish to the `gh-pages` branch:
-          publish_dir: ./build
+          path: ./build
+      - name: Deploy to GitHub Pages
+        uses: actions/deploy-pages@v2
+        if: github.ref == 'refs/heads/main'

--- a/.github/workflows/test-deploy.yml
+++ b/.github/workflows/test-deploy.yml
@@ -22,9 +22,11 @@ jobs:
         run: npm ci
       - name: Test build website
         run: npm run build
-      - name: Deploy
-        uses: peaceiris/actions-gh-pages@v3
-        if: github.ref == 'refs/heads/main'
+
+      - uses: actions/configure-pages@v4
+      - uses: actions/upload-pages-artifact@v2
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./website/build
+          path: ./build
+      - name: Deploy
+        uses: actions/deploy-pages@v2
+        if: github.ref == 'refs/heads/main'


### PR DESCRIPTION
Use deploy-pages instead of peaceiris/actions-gh-pages.
Seems to need an environment variable **ACTIONS_ID_TOKEN_REQUEST_URL** from somewhere, so will need further investigation.