### PR TITLE
Add announcement bar for the new help center 

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -75,12 +75,6 @@ const config = {
             label: 'Help Center',
           },
           {
-            type: 'doc',
-            docId: 'api/index',
-            position: 'left',
-            label: 'API',
-          },
-          {
             to: 'https://famedly.com/',
             label: 'Website',
             position: 'right',
@@ -95,6 +89,10 @@ const config = {
             position: 'right',
           },
         ],
+      },
+      announcementBar: {
+        id: 'announcementBar',
+        content: 'Das Famedly Help Cencer ist umgezogen / The Famedly Help Center has moved: <a href="https://docs.famedly.com">https://docs.famedly.com</a>.',
       },
       footer: {
         copyright: `Copyright © ${new Date().getFullYear()} Famedly GmbH`,

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -409,3 +409,12 @@
 ol ol, ul ol, ol {
   list-style-type: decimal;
 }
+
+div[role='banner'] {
+  background-color: #FFC700;
+  height: 32px;
+}
+div[role='banner'] > div {
+  font-size: 16px;
+  line-height: 24px;
+}


### PR DESCRIPTION
Closes https://github.com/famedly/product-management/issues/2494

Looks like this now: 
![Bildschirmfoto vom 2024-10-15 15-55-30](https://github.com/user-attachments/assets/051e1552-430d-4125-908e-6ef12b085ddf)

The link is working and styling was agreed with @Krzysztof2512
